### PR TITLE
add general shape dividing function with knitted blocks and fixed bug

### DIFF
--- a/app/score_calculator/divide/general_shape.py
+++ b/app/score_calculator/divide/general_shape.py
@@ -8,6 +8,24 @@ from app.score_calculator.block.block import Block
 from app.score_calculator.enums.enums import BlockType, Tile
 from app.score_calculator.hand.hand import Hand
 
+GENERAL_SHAPE_SIZE: Final[int] = 5
+QUAD_SIZE: Final[int] = 4
+TRIPLET_SIZE: Final[int] = 3
+SEQUENCE_SIZE: Final[int] = 3
+KNITTED_SIZE: Final[int] = 3
+KNITTED_GAP: Final[int] = 3
+PAIR_SIZE: Final[int] = 2
+SEQUENCE_MAX_START_POINT: Final[int] = 7
+FULLY_HAND_SIZE: Final[int] = 14
+KNITTED_CASE: Final[list[list[Tile]]] = [
+    [Tile.M1, Tile.M4, Tile.M7, Tile.S2, Tile.S5, Tile.S8, Tile.P3, Tile.P6, Tile.P9],
+    [Tile.M1, Tile.M4, Tile.M7, Tile.P2, Tile.P5, Tile.P8, Tile.S3, Tile.S6, Tile.S9],
+    [Tile.S1, Tile.S4, Tile.S7, Tile.M2, Tile.M5, Tile.M8, Tile.P3, Tile.P6, Tile.P9],
+    [Tile.S1, Tile.S4, Tile.S7, Tile.P2, Tile.P5, Tile.P8, Tile.M3, Tile.M6, Tile.M9],
+    [Tile.P1, Tile.P4, Tile.P7, Tile.M2, Tile.M5, Tile.M8, Tile.S3, Tile.S6, Tile.S9],
+    [Tile.P1, Tile.P4, Tile.P7, Tile.S2, Tile.S5, Tile.S8, Tile.M3, Tile.M6, Tile.M9],
+]
+
 
 @dataclass
 class BlockDivisionState:
@@ -20,8 +38,22 @@ class BlockDivisionState:
 
     @staticmethod
     def create_from_hand(hand: Hand) -> BlockDivisionState:
+        _remaining_tiles_count: list[int] = deepcopy(hand.tiles)
+        for block in hand.call_blocks:
+            if block.type == BlockType.PAIR:
+                _remaining_tiles_count[block.tile] -= PAIR_SIZE
+            elif block.type == BlockType.TRIPLET:
+                _remaining_tiles_count[block.tile] -= TRIPLET_SIZE
+            elif block.type == BlockType.QUAD:
+                _remaining_tiles_count[block.tile] -= QUAD_SIZE
+            elif block.type == BlockType.SEQUENCE:
+                for i in range(SEQUENCE_SIZE):
+                    _remaining_tiles_count[block.tile + i] -= 1
+            elif block.type == BlockType.KNITTED:
+                for i in range(KNITTED_SIZE):
+                    _remaining_tiles_count[block.tile + i * KNITTED_GAP] -= 1
         return BlockDivisionState(
-            remaining_tiles_count=deepcopy(hand.tiles),
+            remaining_tiles_count=_remaining_tiles_count,
             parsed_blocks=deepcopy(hand.call_blocks),
             current_tile=Tile.M1,
             previous_tile=Tile.F0,
@@ -30,11 +62,25 @@ class BlockDivisionState:
         )
 
 
-GENERAL_SHAPE_SIZE: Final[int] = 5
-TRIPLET_SIZE: Final[int] = 3
-PAIR_SIZE: Final[int] = 2
-SEQUENCE_MAX_START_POINT: Final[int] = 7
-FULLY_HAND_SIZE: Final[int] = 14
+def divide_general_shape_knitted_sub(hand: Hand) -> list[list[Block]]:
+    has_knitted_blocks: bool
+    parsed_hands: list[list[Block]] = []
+
+    for one_case in KNITTED_CASE:
+        has_knitted_blocks = True
+        for tile in one_case:
+            if hand.tiles[tile] < 1:
+                has_knitted_blocks = False
+                break
+        if not has_knitted_blocks:
+            continue
+        new_hand = deepcopy(hand)
+        for i in range(0, len(one_case), KNITTED_SIZE):
+            new_hand.call_blocks.append(
+                Block(BlockType.KNITTED, one_case[i], is_opened=False),
+            )
+        parsed_hands.extend(divide_general_shape(new_hand))
+    return parsed_hands
 
 
 def divide_general_shape(hand: Hand) -> list[list[Block]]:
@@ -42,7 +88,6 @@ def divide_general_shape(hand: Hand) -> list[list[Block]]:
 
     stack: list[BlockDivisionState] = []
     stack.append(BlockDivisionState.create_from_hand(hand))
-
     total_tiles_count: int = sum(hand.tiles)
     for block in hand.call_blocks:
         total_tiles_count -= 1 if block.type == BlockType.QUAD else 0
@@ -57,13 +102,11 @@ def divide_general_shape(hand: Hand) -> list[list[Block]]:
         next_tile: Tile = state.current_tile
         while next_tile < Tile.F0 and state.remaining_tiles_count[next_tile] == 0:
             next_tile = next_tile + 1
-
         # end point
         if next_tile >= Tile.F0:
             if len(state.parsed_blocks) == GENERAL_SHAPE_SIZE:
                 parsed_hands.append(state.parsed_blocks)
             continue
-
         # Triplet
         if state.remaining_tiles_count[next_tile] >= TRIPLET_SIZE and (
             state.previous_tile != next_tile or not state.previous_was_sequence
@@ -73,8 +116,9 @@ def divide_general_shape(hand: Hand) -> list[list[Block]]:
             next_state.parsed_blocks.append(
                 Block(type=BlockType.TRIPLET, tile=next_tile, is_opened=False),
             )
+            next_state.previous_was_sequence = False
+            next_state.previous_tile = next_tile
             stack.append(next_state)
-
         # Pair
         if (
             state.remaining_tiles_count[next_tile] >= PAIR_SIZE
@@ -87,8 +131,9 @@ def divide_general_shape(hand: Hand) -> list[list[Block]]:
                 Block(type=BlockType.PAIR, tile=next_tile, is_opened=False),
             )
             next_state.has_pair = True
+            next_state.previous_was_sequence = False
+            next_state.previous_tile = next_tile
             stack.append(next_state)
-
         # Sequence
         if (
             next_tile.is_number()
@@ -104,5 +149,6 @@ def divide_general_shape(hand: Hand) -> list[list[Block]]:
                 Block(type=BlockType.SEQUENCE, tile=next_tile, is_opened=False),
             )
             next_state.previous_was_sequence = True
+            next_state.previous_tile = next_tile
             stack.append(next_state)
     return parsed_hands

--- a/app/score_calculator/divide/general_shape.py
+++ b/app/score_calculator/divide/general_shape.py
@@ -17,7 +17,7 @@ KNITTED_GAP: Final[int] = 3
 PAIR_SIZE: Final[int] = 2
 SEQUENCE_MAX_START_POINT: Final[int] = 7
 FULLY_HAND_SIZE: Final[int] = 14
-KNITTED_CASE: Final[list[list[Tile]]] = [
+KNITTED_CASES: Final[list[list[Tile]]] = [
     [Tile.M1, Tile.M4, Tile.M7, Tile.S2, Tile.S5, Tile.S8, Tile.P3, Tile.P6, Tile.P9],
     [Tile.M1, Tile.M4, Tile.M7, Tile.P2, Tile.P5, Tile.P8, Tile.S3, Tile.S6, Tile.S9],
     [Tile.S1, Tile.S4, Tile.S7, Tile.M2, Tile.M5, Tile.M8, Tile.P3, Tile.P6, Tile.P9],
@@ -66,18 +66,14 @@ def divide_general_shape_knitted_sub(hand: Hand) -> list[list[Block]]:
     has_knitted_blocks: bool
     parsed_hands: list[list[Block]] = []
 
-    for one_case in KNITTED_CASE:
-        has_knitted_blocks = True
-        for tile in one_case:
-            if hand.tiles[tile] < 1:
-                has_knitted_blocks = False
-                break
+    for case in KNITTED_CASES:
+        has_knitted_blocks = all(hand.tiles[tile] > 0 for tile in case)
         if not has_knitted_blocks:
             continue
         new_hand = deepcopy(hand)
-        for i in range(0, len(one_case), KNITTED_SIZE):
+        for i in range(0, len(case), KNITTED_SIZE):
             new_hand.call_blocks.append(
-                Block(BlockType.KNITTED, one_case[i], is_opened=False),
+                Block(BlockType.KNITTED, case[i], is_opened=False),
             )
         parsed_hands.extend(divide_general_shape(new_hand))
     return parsed_hands

--- a/app/score_calculator/divide/general_shape.py
+++ b/app/score_calculator/divide/general_shape.py
@@ -71,10 +71,11 @@ def divide_general_shape_knitted_sub(hand: Hand) -> list[list[Block]]:
         if not has_knitted_blocks:
             continue
         new_hand = deepcopy(hand)
-        for i in range(0, len(case), KNITTED_SIZE):
-            new_hand.call_blocks.append(
-                Block(BlockType.KNITTED, case[i], is_opened=False),
-            )
+        new_hand.call_blocks.extend(
+            Block(type=BlockType.KNITTED, tile=start_tile, is_opened=False)
+            for start_tile in case[::KNITTED_GAP]
+        )
+
         parsed_hands.extend(divide_general_shape(new_hand))
     return parsed_hands
 

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,5 +1,9 @@
+from app.score_calculator.divide.general_shape import (
+    divide_general_shape,
+    divide_general_shape_knitted_sub,
+)
 from app.score_calculator.hand.hand import Hand
-from tests.test_utils import raw_string_to_hand_class
+from tests.test_utils import print_blocks, raw_string_to_hand_class
 
 
 def test_sample():
@@ -17,8 +21,20 @@ def test_print_output():
 
 
 def test_print_string_to_hand_1():
-    print_hand(raw_string_to_hand_class("1112345678999m"))
+    print_hand(raw_string_to_hand_class("1112345678999m9m"))
     print_hand(raw_string_to_hand_class("123m123p123s777z11z"))
     print_hand(raw_string_to_hand_class("123m123p123s11z[888p]"))
     print_hand(raw_string_to_hand_class("123m[888p]123p123s11z"))
+    assert True
+
+
+def test_general_hand_parse():
+    hand = raw_string_to_hand_class("1112345678999m9m")
+    print(hand)
+    for blocks in divide_general_shape(hand):
+        print_blocks(blocks)
+    hand = raw_string_to_hand_class("147m258s369p111m11z")
+    print(hand)
+    for blocks in divide_general_shape_knitted_sub(hand):
+        print_blocks(blocks)
     assert True

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,8 +54,44 @@ def raw_string_to_hand_class(string: str) -> Hand:
                 tile_stack.append(c)
                 continue
             for num in tile_stack:
-                print("tile:", num + c, name_to_tile(num + c))
+                # print("tile:", num + c, name_to_tile(num + c))
                 tiles_count[name_to_tile(num + c)] += 1
 
             tile_stack.clear()
     return Hand(tiles_count, blocks_list)
+
+
+SEQUENCE_SIZE: Final[int] = 3
+
+
+def print_blocks(blocks: list[Block]):
+    for block in blocks:
+        print_block(block)
+    print()
+
+
+BLOCKTYPE_SIZE: dict[BlockType, int] = {
+    BlockType.PAIR: 2,
+    BlockType.TRIPLET: 3,
+    BlockType.QUAD: 4,
+}
+
+
+def print_block(block: Block):
+    if block.is_opened:
+        print("[", end="")
+    elif block.type == BlockType.QUAD:
+        print("{", end="")
+    if block.type in {BlockType.PAIR, BlockType.TRIPLET, BlockType.QUAD}:
+        print(tile_to_name(block.tile) * BLOCKTYPE_SIZE[block.type], end="")
+    elif block.type == BlockType.SEQUENCE:
+        for i in range(SEQUENCE_SIZE):
+            print(tile_to_name(block.tile + i), end="")
+    elif block.type == BlockType.KNITTED:
+        for i in range(SEQUENCE_SIZE):
+            print(tile_to_name(block.tile + i * SEQUENCE_SIZE), end="")
+    if block.is_opened:
+        print("]", end="")
+    elif block.type == BlockType.QUAD:
+        print("}", end="")
+    print(" ", end="")


### PR DESCRIPTION
### general_shape.py
1. 일반형 + 조합룡 파싱 함수를 추가했습니다.
2. 일반형 파싱 함수의 오류를 정상 작동하도록 수정했습니다. (기존 c++ 재귀코드를 stack사용한 python코드로 옮기는 과정에서 생긴 오류)
- 이런식으로 같은 형태가 중복해서 세어졌음
```bash
1m2m3m 1m1m 4m5m6m 7m8m9m 9m9m9m
1m1m 1m2m3m 4m5m6m 7m8m9m 9m9m9m
```
- 파싱 함수 시작부분에 확정된 블럭의 tile(e.g. 후로 블럭)들을 tile리스트에서 제거하는 로직 추가

### test_utils.py
테스트용 Block, list[Block]을 출력하는 함수를 만들었습니다

