### PR TITLE
add three blocks yaku checker

### DIFF
--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -95,11 +95,8 @@ class BlocksYakuChecker(YakuChecker):
             for pair in zip(self.tile_numbers, self.tile_numbers[1:])
         )
 
-    def validate_all_condition(self, condition: Callable[[Block], bool]) -> bool:
+    def validate_all(self, condition: Callable[[Block], bool]) -> bool:
         return all(condition(block) for block in self.blocks)
-
-    def validate_all_properties(self, *conditions: Callable[[Block], bool]) -> bool:
-        return all(self.validate_all_condition(condition) for condition in conditions)
 
     def count_blocks_if(self, condition: Callable[[Block], bool]) -> int:
         return sum(1 for block in self.blocks if condition(block))
@@ -114,7 +111,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def _is_pure_chow(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 1
             and all(self.blocks[0].tile == block.tile for block in self.blocks)
         )
@@ -122,7 +119,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def _is_pure_shifted_pungs(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            self.validate_all(lambda x: x.is_number and x.is_pung)
             and self.tile_type_count == 1
             and self.has_constant_gap(1)
         )
@@ -130,18 +127,18 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def _is_pure_shifted_chows(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 1
             and (self.has_constant_gap(1) or self.has_constant_gap(2))
         )
 
     @property
     def _is_big_winds(self) -> bool:
-        return self.validate_all_properties(lambda x: x.is_wind, lambda x: x.is_pung)
+        return self.validate_all(lambda x: x.is_wind and x.is_pung)
 
     @property
     def _is_big_dragons(self) -> bool:
-        return self.validate_all_properties(lambda x: x.is_dragon, lambda x: x.is_pung)
+        return self.validate_all(lambda x: x.is_dragon and x.is_pung)
 
     # three blocks checker
     @property
@@ -151,7 +148,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_little_three_dragons(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_dragon)
+            self.validate_all(lambda x: x.is_dragon)
             and self.count_blocks_if(lambda x: x.is_pair) == 1
             and self.count_blocks_if(lambda x: x.is_pung) == 2
         )
@@ -171,7 +168,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_pure_straight(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 1
             and self.has_constant_gap(self.STRAIGHT_GAP)
         )
@@ -179,7 +176,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_triple_pung(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            self.validate_all(lambda x: x.is_number and x.is_pung)
             and self.tile_type_count == 3
             and self.count_blocks_if(
                 lambda x: x.tile.number == self.blocks[0].tile.number,
@@ -194,10 +191,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_knitted_straight(self) -> bool:
         return (
-            self.validate_all_properties(
-                lambda x: x.is_number,
-                lambda x: x.type == BlockType.KNITTED,
-            )
+            self.validate_all(lambda x: x.is_number and x.type == BlockType.KNITTED)
             and self.tile_type_count == 3
             and self.has_constant_gap(1)
         )
@@ -205,14 +199,14 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_triple_chow(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self._is_mixed_same_num
         )
 
     @property
     def is_mixed_straight(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 3
             and self.has_constant_gap(self.STRAIGHT_GAP)
         )
@@ -220,7 +214,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_shifted_pungs(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            self.validate_all(lambda x: x.is_number and x.is_pung)
             and self.tile_type_count == 3
             and self.has_constant_gap(1)
         )
@@ -228,7 +222,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_shifted_chows(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 3
             and (self.has_constant_gap(1) or self.has_constant_gap(2))
         )
@@ -236,12 +230,12 @@ class BlocksYakuChecker(YakuChecker):
     # two blocks checker
     @property
     def is_two_dragons_pungs(self) -> bool:
-        return self.validate_all_properties(lambda x: x.is_dragon, lambda x: x.is_pung)
+        return self.validate_all(lambda x: x.is_dragon and x.is_pung)
 
     @property
     def is_double_pung(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            self.validate_all(lambda x: x.is_number and x.is_pung)
             and self._is_mixed_same_num
         )
 
@@ -252,25 +246,21 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_double_chow(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            self.validate_all(lambda x: x.is_number and x.is_sequence)
             and self._is_mixed_same_num
         )
 
     @property
     def is_short_straight(self) -> bool:
-        return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and len(self.blocks) == 2
-            and self.has_constant_gap(self.STRAIGHT_GAP)
-        )
+        return self.validate_all(
+            lambda x: x.is_number and x.is_sequence,
+        ) and self.has_constant_gap(self.STRAIGHT_GAP)
 
     @property
     def is_two_terminal_chows(self) -> bool:
-        return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and len(self.blocks) == 2
-            and self.has_constant_gap(self.TERMINAL_GAP)
-        )
+        return self.validate_all(
+            lambda x: x.is_number and x.is_sequence,
+        ) and self.has_constant_gap(self.TERMINAL_GAP)
 
     # four blocks checker
     @property
@@ -280,7 +270,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_little_four_winds(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_wind)
+            self.validate_all(lambda x: x.is_wind)
             and self.count_blocks_if(lambda x: x.is_pair) == 1
             and self.count_blocks_if(lambda x: x.is_pung) == 3
         )
@@ -300,8 +290,8 @@ class BlocksYakuChecker(YakuChecker):
     # five blocks checker
     @property
     def is_outside_hand(self) -> bool:
-        return self.validate_all_properties(lambda x: x.has_outside)
+        return self.validate_all(lambda x: x.has_outside)
 
     @property
     def is_all_fives(self) -> bool:
-        return self.validate_all_properties(lambda x: x.has_five)
+        return self.validate_all(lambda x: x.has_five)

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -32,7 +32,7 @@ class BlocksYakuChecker(YakuChecker):
         checkers = {
             5: self.five_blocks_checker,
             4: self.four_blocks_checker,
-            3: None,  # Not implemented for triple blocks
+            3: self.three_blocks_checker,
             2: self.two_blocks_checker,
             1: None,  # Not implemented for single blocks
         }
@@ -53,6 +53,34 @@ class BlocksYakuChecker(YakuChecker):
         ]
         return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
 
+    def four_blocks_checker(self) -> Yaku:
+        conditions = [
+            (self.is_big_four_winds, Yaku.BigFourWinds),
+            (self.is_little_four_winds, Yaku.LittleFourWinds),
+            (self.is_quadruple_chow, Yaku.QuadrupleChow),
+            (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
+            (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
+        ]
+        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
+
+    def three_blocks_checker(self) -> Yaku:
+        conditions = [
+            (self.is_big_three_dragons, Yaku.BigThreeDragons),
+            (self.is_little_three_dragons, Yaku.LittleThreeDragons),
+            (self.is_pure_triple_chow, Yaku.PureTripleChow),
+            (self.is_pure_shifted_pungs, Yaku.PureShiftedPungs),
+            (self.is_pure_shifted_chows, Yaku.PureShiftedChows),
+            (self.is_pure_straight, Yaku.PureStraight),
+            (self.is_triple_pung, Yaku.TriplePung),
+            (self.is_big_three_winds, Yaku.BigThreeWinds),
+            (self.is_knitted_straight, Yaku.KnittedStraight),
+            (self.is_mixed_triple_chow, Yaku.MixedTripleChow),
+            (self.is_mixed_straight, Yaku.MixedStraight),
+            (self.is_mixed_shifted_pungs, Yaku.MixedShiftedPungs),
+            (self.is_mixed_shifted_chows, Yaku.MixedShiftedChows),
+        ]
+        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
+
     def two_blocks_checker(self) -> Yaku:
         conditions = [
             (self.is_two_dragons_pungs, Yaku.TwoDragonsPungs),
@@ -61,16 +89,6 @@ class BlocksYakuChecker(YakuChecker):
             (self.is_mixed_double_chow, Yaku.MixedDoubleChow),
             (self.is_short_straight, Yaku.ShortStraight),
             (self.is_two_terminal_chows, Yaku.TwoTerminalChows),
-        ]
-        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
-
-    def four_blocks_checker(self) -> Yaku:
-        conditions = [
-            (self.is_big_four_winds, Yaku.BigFourWinds),
-            (self.is_little_four_winds, Yaku.LittleFourWinds),
-            (self.is_quadruple_chow, Yaku.QuadrupleChow),
-            (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
-            (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
         ]
         return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
 
@@ -103,19 +121,140 @@ class BlocksYakuChecker(YakuChecker):
     def validate_all_properties(self, *conditions: Callable[[Block], bool]) -> bool:
         return all(self.validate_all_condition(condition) for condition in conditions)
 
+    def count_blocks_if(self, condition: Callable[[Block], bool]) -> int:
+        return sum(1 for block in self.blocks if condition(block))
+
     # general yaku checker
     @property
-    def is_mixed_same_num(self) -> bool:
+    def is_mixed_same_num_general(self) -> bool:
         return self.tile_type_count == len(self.blocks) and all(
             self.blocks[0].tile.number == block.tile.number for block in self.blocks
         )
 
     @property
-    def is_pure_chow(self) -> bool:
+    def is_pure_chow_general(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_sequence)
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
             and self.tile_type_count == self.SINGLE
             and all(self.blocks[0].tile == block.tile for block in self.blocks)
+        )
+
+    @property
+    def is_pure_shifted_pungs_general(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            and self.tile_type_count == 1
+            and self.has_constant_gap(self.SINGLE)
+        )
+
+    @property
+    def is_pure_shifted_chows_general(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            and self.tile_type_count == 1
+            and (
+                self.has_constant_gap(self.SINGLE) or self.has_constant_gap(self.DOUBLE)
+            )
+        )
+
+    @property
+    def is_big_winds_general(self) -> bool:
+        return self.validate_all_properties(lambda x: x.is_wind, lambda x: x.is_pung)
+
+    @property
+    def is_big_dragons_general(self) -> bool:
+        return self.validate_all_properties(lambda x: x.is_dragon, lambda x: x.is_pung)
+
+    # three blocks checker
+    @property
+    def is_big_three_dragons(self) -> bool:
+        return self.is_big_dragons_general
+
+    @property
+    def is_little_three_dragons(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_dragon)
+            and self.count_blocks_if(lambda x: x.is_pair) == 1
+            and self.count_blocks_if(lambda x: x.is_pung) == self.DOUBLE
+        )
+
+    @property
+    def is_pure_triple_chow(self) -> bool:
+        return self.is_pure_chow_general
+
+    @property
+    def is_pure_shifted_pungs(self) -> bool:
+        return self.is_pure_shifted_pungs_general
+
+    @property
+    def is_pure_shifted_chows(self) -> bool:
+        return self.is_pure_shifted_chows_general
+
+    @property
+    def is_pure_straight(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            and self.tile_type_count == 1
+            and self.has_constant_gap(self.STRAIGHT_GAP)
+        )
+
+    @property
+    def is_triple_pung(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            and self.tile_type_count == self.TRIPLE
+            and self.count_blocks_if(
+                lambda x: x.tile.number == self.blocks[0].tile.number,
+            )
+            == self.TRIPLE
+        )
+
+    @property
+    def is_big_three_winds(self) -> bool:
+        return self.is_big_winds_general
+
+    @property
+    def is_knitted_straight(self) -> bool:
+        return (
+            self.validate_all_properties(
+                lambda x: x.is_number,
+                lambda x: x.type == BlockType.KNITTED,
+            )
+            and self.tile_type_count == self.TRIPLE
+            and self.has_constant_gap(1)
+        )
+
+    @property
+    def is_mixed_triple_chow(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            and self.is_mixed_same_num_general
+        )
+
+    @property
+    def is_mixed_straight(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            and self.tile_type_count == self.TRIPLE
+            and self.has_constant_gap(self.STRAIGHT_GAP)
+        )
+
+    @property
+    def is_mixed_shifted_pungs(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
+            and self.tile_type_count == self.TRIPLE
+            and self.has_constant_gap(self.SINGLE)
+        )
+
+    @property
+    def is_mixed_shifted_chows(self) -> bool:
+        return (
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            and self.tile_type_count == self.TRIPLE
+            and (
+                self.has_constant_gap(self.SINGLE) or self.has_constant_gap(self.DOUBLE)
+            )
         )
 
     # two blocks checker
@@ -127,69 +266,60 @@ class BlocksYakuChecker(YakuChecker):
     def is_double_pung(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
-            and self.is_mixed_same_num
+            and self.is_mixed_same_num_general
         )
 
     @property
     def is_pure_double_chow(self) -> bool:
-        return self.is_pure_chow
+        return self.is_pure_chow_general
 
     @property
     def is_mixed_double_chow(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_sequence)
-            and self.is_mixed_same_num
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
+            and self.is_mixed_same_num_general
         )
 
     @property
     def is_short_straight(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_sequence)
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
             and len(self.blocks) == self.DOUBLE
-            and abs(self.blocks[0].tile - self.blocks[1].tile) == self.STRAIGHT_GAP
+            and self.has_constant_gap(self.STRAIGHT_GAP)
         )
 
     @property
     def is_two_terminal_chows(self) -> bool:
         return (
-            self.validate_all_properties(lambda x: x.is_sequence)
+            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
             and len(self.blocks) == self.DOUBLE
-            and abs(self.blocks[0].tile - self.blocks[1].tile) == self.TERMINAL_GAP
+            and self.has_constant_gap(self.TERMINAL_GAP)
         )
 
     # four blocks checker
     @property
     def is_big_four_winds(self) -> bool:
-        return self.validate_all_properties(lambda x: x.is_wind, lambda x: x.is_pung)
+        return self.is_big_winds_general
 
     @property
     def is_little_four_winds(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_wind)
-            and sum(1 for block in self.blocks if block.type == BlockType.PAIR) == 1
+            and self.count_blocks_if(lambda x: x.is_pair) == 1
+            and self.count_blocks_if(lambda x: x.is_pung) == self.TRIPLE
         )
 
     @property
     def is_quadruple_chow(self) -> bool:
-        return self.is_pure_chow
+        return self.is_pure_chow_general
 
     @property
     def is_four_pure_shifted_pungs(self) -> bool:
-        return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
-            and self.tile_type_count == 1
-            and self.has_constant_gap(self.SINGLE)
-        )
+        return self.is_pure_shifted_pungs_general
 
     @property
     def is_four_pure_shifted_chows(self) -> bool:
-        return (
-            self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and self.tile_type_count == 1
-            and (
-                self.has_constant_gap(self.SINGLE) or self.has_constant_gap(self.DOUBLE)
-            )
-        )
+        return self.is_pure_shifted_chows_general
 
     # five blocks checker
     @property

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -13,6 +13,42 @@ class BlocksYakuChecker(YakuChecker):
         super().__init__()
         self.blocks: list[Block] = blocks
         self._yaku: Yaku
+        self.conditions: dict[int, list[tuple[bool, Yaku]]] = {
+            2: [
+                (self.is_two_dragons_pungs, Yaku.TwoDragonsPungs),
+                (self.is_double_pung, Yaku.DoublePung),
+                (self.is_pure_double_chow, Yaku.PureDoubleChow),
+                (self.is_mixed_double_chow, Yaku.MixedDoubleChow),
+                (self.is_short_straight, Yaku.ShortStraight),
+                (self.is_two_terminal_chows, Yaku.TwoTerminalChows),
+            ],
+            3: [
+                (self.is_big_three_dragons, Yaku.BigThreeDragons),
+                (self.is_little_three_dragons, Yaku.LittleThreeDragons),
+                (self.is_pure_triple_chow, Yaku.PureTripleChow),
+                (self.is_pure_shifted_pungs, Yaku.PureShiftedPungs),
+                (self.is_pure_shifted_chows, Yaku.PureShiftedChows),
+                (self.is_pure_straight, Yaku.PureStraight),
+                (self.is_triple_pung, Yaku.TriplePung),
+                (self.is_big_three_winds, Yaku.BigThreeWinds),
+                (self.is_knitted_straight, Yaku.KnittedStraight),
+                (self.is_mixed_triple_chow, Yaku.MixedTripleChow),
+                (self.is_mixed_straight, Yaku.MixedStraight),
+                (self.is_mixed_shifted_pungs, Yaku.MixedShiftedPungs),
+                (self.is_mixed_shifted_chows, Yaku.MixedShiftedChows),
+            ],
+            4: [
+                (self.is_big_four_winds, Yaku.BigFourWinds),
+                (self.is_little_four_winds, Yaku.LittleFourWinds),
+                (self.is_quadruple_chow, Yaku.QuadrupleChow),
+                (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
+                (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
+            ],
+            5: [
+                (self.is_all_fives, Yaku.AllFives),
+                (self.is_outside_hand, Yaku.OutsideHand),
+            ],
+        }
         self.set_yaku()
 
     STRAIGHT_GAP: Final[int] = 3
@@ -26,51 +62,12 @@ class BlocksYakuChecker(YakuChecker):
         self._yaku = self.blocks_checker()
 
     def blocks_checker(self) -> Yaku:
-        conditions: list[tuple[bool, Yaku]]
-        match len(self.blocks):
-            case 5:
-                conditions = [
-                    (self.is_all_fives, Yaku.AllFives),
-                    (self.is_outside_hand, Yaku.OutsideHand),
-                ]
-            case 4:
-                conditions = [
-                    (self.is_big_four_winds, Yaku.BigFourWinds),
-                    (self.is_little_four_winds, Yaku.LittleFourWinds),
-                    (self.is_quadruple_chow, Yaku.QuadrupleChow),
-                    (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
-                    (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
-                ]
-            case 3:
-                conditions = [
-                    (self.is_big_three_dragons, Yaku.BigThreeDragons),
-                    (self.is_little_three_dragons, Yaku.LittleThreeDragons),
-                    (self.is_pure_triple_chow, Yaku.PureTripleChow),
-                    (self.is_pure_shifted_pungs, Yaku.PureShiftedPungs),
-                    (self.is_pure_shifted_chows, Yaku.PureShiftedChows),
-                    (self.is_pure_straight, Yaku.PureStraight),
-                    (self.is_triple_pung, Yaku.TriplePung),
-                    (self.is_big_three_winds, Yaku.BigThreeWinds),
-                    (self.is_knitted_straight, Yaku.KnittedStraight),
-                    (self.is_mixed_triple_chow, Yaku.MixedTripleChow),
-                    (self.is_mixed_straight, Yaku.MixedStraight),
-                    (self.is_mixed_shifted_pungs, Yaku.MixedShiftedPungs),
-                    (self.is_mixed_shifted_chows, Yaku.MixedShiftedChows),
-                ]
-            case 2:
-                conditions = [
-                    (self.is_two_dragons_pungs, Yaku.TwoDragonsPungs),
-                    (self.is_double_pung, Yaku.DoublePung),
-                    (self.is_pure_double_chow, Yaku.PureDoubleChow),
-                    (self.is_mixed_double_chow, Yaku.MixedDoubleChow),
-                    (self.is_short_straight, Yaku.ShortStraight),
-                    (self.is_two_terminal_chows, Yaku.TwoTerminalChows),
-                ]
-            case 1:
-                conditions = []
-            case _:
-                raise IndexError("Invalid blocks size.")
-        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
+        if len(self.blocks) not in {1, 2, 3, 4, 5}:
+            raise IndexError("Invalid blocks size.")
+        return next(
+            (yaku for checker, yaku in self.conditions[len(self.blocks)] if checker),
+            Yaku.ERROR,
+        )
 
     # utils
     @property

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -15,12 +15,6 @@ class BlocksYakuChecker(YakuChecker):
         self._yaku: Yaku
         self.set_yaku()
 
-    SINGLE: Final[int] = 1
-    DOUBLE: Final[int] = 2
-    TRIPLE: Final[int] = 3
-    FOUR: Final[int] = 4
-    FIVE: Final[int] = 5
-
     STRAIGHT_GAP: Final[int] = 3
     TERMINAL_GAP: Final[int] = 6
 
@@ -135,7 +129,7 @@ class BlocksYakuChecker(YakuChecker):
     def is_pure_chow_general(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and self.tile_type_count == self.SINGLE
+            and self.tile_type_count == 1
             and all(self.blocks[0].tile == block.tile for block in self.blocks)
         )
 
@@ -144,7 +138,7 @@ class BlocksYakuChecker(YakuChecker):
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
             and self.tile_type_count == 1
-            and self.has_constant_gap(self.SINGLE)
+            and self.has_constant_gap(1)
         )
 
     @property
@@ -152,9 +146,7 @@ class BlocksYakuChecker(YakuChecker):
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
             and self.tile_type_count == 1
-            and (
-                self.has_constant_gap(self.SINGLE) or self.has_constant_gap(self.DOUBLE)
-            )
+            and (self.has_constant_gap(1) or self.has_constant_gap(2))
         )
 
     @property
@@ -175,7 +167,7 @@ class BlocksYakuChecker(YakuChecker):
         return (
             self.validate_all_properties(lambda x: x.is_dragon)
             and self.count_blocks_if(lambda x: x.is_pair) == 1
-            and self.count_blocks_if(lambda x: x.is_pung) == self.DOUBLE
+            and self.count_blocks_if(lambda x: x.is_pung) == 2
         )
 
     @property
@@ -202,11 +194,11 @@ class BlocksYakuChecker(YakuChecker):
     def is_triple_pung(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
-            and self.tile_type_count == self.TRIPLE
+            and self.tile_type_count == 3
             and self.count_blocks_if(
                 lambda x: x.tile.number == self.blocks[0].tile.number,
             )
-            == self.TRIPLE
+            == 3
         )
 
     @property
@@ -220,7 +212,7 @@ class BlocksYakuChecker(YakuChecker):
                 lambda x: x.is_number,
                 lambda x: x.type == BlockType.KNITTED,
             )
-            and self.tile_type_count == self.TRIPLE
+            and self.tile_type_count == 3
             and self.has_constant_gap(1)
         )
 
@@ -235,7 +227,7 @@ class BlocksYakuChecker(YakuChecker):
     def is_mixed_straight(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and self.tile_type_count == self.TRIPLE
+            and self.tile_type_count == 3
             and self.has_constant_gap(self.STRAIGHT_GAP)
         )
 
@@ -243,18 +235,16 @@ class BlocksYakuChecker(YakuChecker):
     def is_mixed_shifted_pungs(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
-            and self.tile_type_count == self.TRIPLE
-            and self.has_constant_gap(self.SINGLE)
+            and self.tile_type_count == 3
+            and self.has_constant_gap(1)
         )
 
     @property
     def is_mixed_shifted_chows(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and self.tile_type_count == self.TRIPLE
-            and (
-                self.has_constant_gap(self.SINGLE) or self.has_constant_gap(self.DOUBLE)
-            )
+            and self.tile_type_count == 3
+            and (self.has_constant_gap(1) or self.has_constant_gap(2))
         )
 
     # two blocks checker
@@ -284,7 +274,7 @@ class BlocksYakuChecker(YakuChecker):
     def is_short_straight(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and len(self.blocks) == self.DOUBLE
+            and len(self.blocks) == 2
             and self.has_constant_gap(self.STRAIGHT_GAP)
         )
 
@@ -292,7 +282,7 @@ class BlocksYakuChecker(YakuChecker):
     def is_two_terminal_chows(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and len(self.blocks) == self.DOUBLE
+            and len(self.blocks) == 2
             and self.has_constant_gap(self.TERMINAL_GAP)
         )
 
@@ -306,7 +296,7 @@ class BlocksYakuChecker(YakuChecker):
         return (
             self.validate_all_properties(lambda x: x.is_wind)
             and self.count_blocks_if(lambda x: x.is_pair) == 1
-            and self.count_blocks_if(lambda x: x.is_pung) == self.TRIPLE
+            and self.count_blocks_if(lambda x: x.is_pung) == 3
         )
 
     @property

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -23,67 +23,53 @@ class BlocksYakuChecker(YakuChecker):
         return self._yaku
 
     def set_yaku(self) -> None:
-        checkers = {
-            5: self.five_blocks_checker,
-            4: self.four_blocks_checker,
-            3: self.three_blocks_checker,
-            2: self.two_blocks_checker,
-            1: None,  # Not implemented for single blocks
-        }
-        block_len = len(self.blocks)
-        if block_len not in checkers:
-            raise IndexError("Invalid blocks size.")
-        if (checker := checkers[block_len]) is None:
-            raise NotImplementedError(
-                f"Checker for blocks size {block_len} is not implemented",
-            )
-        self._yaku = checker()
+        self._yaku = self.blocks_checker()
 
-    # one checker per block size
-    def five_blocks_checker(self) -> Yaku:
-        conditions = [
-            (self.is_all_fives, Yaku.AllFives),
-            (self.is_outside_hand, Yaku.OutsideHand),
-        ]
-        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
-
-    def four_blocks_checker(self) -> Yaku:
-        conditions = [
-            (self.is_big_four_winds, Yaku.BigFourWinds),
-            (self.is_little_four_winds, Yaku.LittleFourWinds),
-            (self.is_quadruple_chow, Yaku.QuadrupleChow),
-            (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
-            (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
-        ]
-        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
-
-    def three_blocks_checker(self) -> Yaku:
-        conditions = [
-            (self.is_big_three_dragons, Yaku.BigThreeDragons),
-            (self.is_little_three_dragons, Yaku.LittleThreeDragons),
-            (self.is_pure_triple_chow, Yaku.PureTripleChow),
-            (self.is_pure_shifted_pungs, Yaku.PureShiftedPungs),
-            (self.is_pure_shifted_chows, Yaku.PureShiftedChows),
-            (self.is_pure_straight, Yaku.PureStraight),
-            (self.is_triple_pung, Yaku.TriplePung),
-            (self.is_big_three_winds, Yaku.BigThreeWinds),
-            (self.is_knitted_straight, Yaku.KnittedStraight),
-            (self.is_mixed_triple_chow, Yaku.MixedTripleChow),
-            (self.is_mixed_straight, Yaku.MixedStraight),
-            (self.is_mixed_shifted_pungs, Yaku.MixedShiftedPungs),
-            (self.is_mixed_shifted_chows, Yaku.MixedShiftedChows),
-        ]
-        return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
-
-    def two_blocks_checker(self) -> Yaku:
-        conditions = [
-            (self.is_two_dragons_pungs, Yaku.TwoDragonsPungs),
-            (self.is_double_pung, Yaku.DoublePung),
-            (self.is_pure_double_chow, Yaku.PureDoubleChow),
-            (self.is_mixed_double_chow, Yaku.MixedDoubleChow),
-            (self.is_short_straight, Yaku.ShortStraight),
-            (self.is_two_terminal_chows, Yaku.TwoTerminalChows),
-        ]
+    def blocks_checker(self) -> Yaku:
+        conditions: list[tuple[bool, Yaku]]
+        match len(self.blocks):
+            case 5:
+                conditions = [
+                    (self.is_all_fives, Yaku.AllFives),
+                    (self.is_outside_hand, Yaku.OutsideHand),
+                ]
+            case 4:
+                conditions = [
+                    (self.is_big_four_winds, Yaku.BigFourWinds),
+                    (self.is_little_four_winds, Yaku.LittleFourWinds),
+                    (self.is_quadruple_chow, Yaku.QuadrupleChow),
+                    (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
+                    (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
+                ]
+            case 3:
+                conditions = [
+                    (self.is_big_three_dragons, Yaku.BigThreeDragons),
+                    (self.is_little_three_dragons, Yaku.LittleThreeDragons),
+                    (self.is_pure_triple_chow, Yaku.PureTripleChow),
+                    (self.is_pure_shifted_pungs, Yaku.PureShiftedPungs),
+                    (self.is_pure_shifted_chows, Yaku.PureShiftedChows),
+                    (self.is_pure_straight, Yaku.PureStraight),
+                    (self.is_triple_pung, Yaku.TriplePung),
+                    (self.is_big_three_winds, Yaku.BigThreeWinds),
+                    (self.is_knitted_straight, Yaku.KnittedStraight),
+                    (self.is_mixed_triple_chow, Yaku.MixedTripleChow),
+                    (self.is_mixed_straight, Yaku.MixedStraight),
+                    (self.is_mixed_shifted_pungs, Yaku.MixedShiftedPungs),
+                    (self.is_mixed_shifted_chows, Yaku.MixedShiftedChows),
+                ]
+            case 2:
+                conditions = [
+                    (self.is_two_dragons_pungs, Yaku.TwoDragonsPungs),
+                    (self.is_double_pung, Yaku.DoublePung),
+                    (self.is_pure_double_chow, Yaku.PureDoubleChow),
+                    (self.is_mixed_double_chow, Yaku.MixedDoubleChow),
+                    (self.is_short_straight, Yaku.ShortStraight),
+                    (self.is_two_terminal_chows, Yaku.TwoTerminalChows),
+                ]
+            case 1:
+                conditions = []
+            case _:
+                raise IndexError("Invalid blocks size.")
         return next((yaku for checker, yaku in conditions if checker), Yaku.ERROR)
 
     # utils

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -62,7 +62,7 @@ class BlocksYakuChecker(YakuChecker):
         self._yaku = self.blocks_checker()
 
     def blocks_checker(self) -> Yaku:
-        if len(self.blocks) not in {1, 2, 3, 4, 5}:
+        if len(self.blocks) not in self.conditions:
             raise IndexError("Invalid blocks size.")
         return next(
             (yaku for checker, yaku in self.conditions[len(self.blocks)] if checker),
@@ -92,7 +92,7 @@ class BlocksYakuChecker(YakuChecker):
             for pair in zip(self.tile_numbers, self.tile_numbers[1:])
         )
 
-    def validate_all(self, condition: Callable[[Block], bool]) -> bool:
+    def validate_blocks(self, condition: Callable[[Block], bool]) -> bool:
         return all(condition(block) for block in self.blocks)
 
     def count_blocks_if(self, condition: Callable[[Block], bool]) -> int:
@@ -108,7 +108,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def _is_pure_chow(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 1
             and all(self.blocks[0].tile == block.tile for block in self.blocks)
         )
@@ -116,7 +116,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def _is_pure_shifted_pungs(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_pung)
+            self.validate_blocks(lambda x: x.is_number and x.is_pung)
             and self.tile_type_count == 1
             and self.has_constant_gap(1)
         )
@@ -124,18 +124,18 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def _is_pure_shifted_chows(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 1
             and (self.has_constant_gap(1) or self.has_constant_gap(2))
         )
 
     @property
     def _is_big_winds(self) -> bool:
-        return self.validate_all(lambda x: x.is_wind and x.is_pung)
+        return self.validate_blocks(lambda x: x.is_wind and x.is_pung)
 
     @property
     def _is_big_dragons(self) -> bool:
-        return self.validate_all(lambda x: x.is_dragon and x.is_pung)
+        return self.validate_blocks(lambda x: x.is_dragon and x.is_pung)
 
     # three blocks checker
     @property
@@ -145,7 +145,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_little_three_dragons(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_dragon)
+            self.validate_blocks(lambda x: x.is_dragon)
             and self.count_blocks_if(lambda x: x.is_pair) == 1
             and self.count_blocks_if(lambda x: x.is_pung) == 2
         )
@@ -165,7 +165,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_pure_straight(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 1
             and self.has_constant_gap(self.STRAIGHT_GAP)
         )
@@ -173,7 +173,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_triple_pung(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_pung)
+            self.validate_blocks(lambda x: x.is_number and x.is_pung)
             and self.tile_type_count == 3
             and self.count_blocks_if(
                 lambda x: x.tile.number == self.blocks[0].tile.number,
@@ -188,7 +188,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_knitted_straight(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.type == BlockType.KNITTED)
+            self.validate_blocks(lambda x: x.is_number and x.type == BlockType.KNITTED)
             and self.tile_type_count == 3
             and self.has_constant_gap(1)
         )
@@ -196,14 +196,14 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_triple_chow(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self._is_mixed_same_num
         )
 
     @property
     def is_mixed_straight(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 3
             and self.has_constant_gap(self.STRAIGHT_GAP)
         )
@@ -211,7 +211,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_shifted_pungs(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_pung)
+            self.validate_blocks(lambda x: x.is_number and x.is_pung)
             and self.tile_type_count == 3
             and self.has_constant_gap(1)
         )
@@ -219,7 +219,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_shifted_chows(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self.tile_type_count == 3
             and (self.has_constant_gap(1) or self.has_constant_gap(2))
         )
@@ -227,12 +227,12 @@ class BlocksYakuChecker(YakuChecker):
     # two blocks checker
     @property
     def is_two_dragons_pungs(self) -> bool:
-        return self.validate_all(lambda x: x.is_dragon and x.is_pung)
+        return self.validate_blocks(lambda x: x.is_dragon and x.is_pung)
 
     @property
     def is_double_pung(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_pung)
+            self.validate_blocks(lambda x: x.is_number and x.is_pung)
             and self._is_mixed_same_num
         )
 
@@ -243,19 +243,19 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_mixed_double_chow(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_number and x.is_sequence)
+            self.validate_blocks(lambda x: x.is_number and x.is_sequence)
             and self._is_mixed_same_num
         )
 
     @property
     def is_short_straight(self) -> bool:
-        return self.validate_all(
+        return self.validate_blocks(
             lambda x: x.is_number and x.is_sequence,
         ) and self.has_constant_gap(self.STRAIGHT_GAP)
 
     @property
     def is_two_terminal_chows(self) -> bool:
-        return self.validate_all(
+        return self.validate_blocks(
             lambda x: x.is_number and x.is_sequence,
         ) and self.has_constant_gap(self.TERMINAL_GAP)
 
@@ -267,7 +267,7 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_little_four_winds(self) -> bool:
         return (
-            self.validate_all(lambda x: x.is_wind)
+            self.validate_blocks(lambda x: x.is_wind)
             and self.count_blocks_if(lambda x: x.is_pair) == 1
             and self.count_blocks_if(lambda x: x.is_pung) == 3
         )
@@ -287,8 +287,8 @@ class BlocksYakuChecker(YakuChecker):
     # five blocks checker
     @property
     def is_outside_hand(self) -> bool:
-        return self.validate_all(lambda x: x.has_outside)
+        return self.validate_blocks(lambda x: x.has_outside)
 
     @property
     def is_all_fives(self) -> bool:
-        return self.validate_all(lambda x: x.has_five)
+        return self.validate_blocks(lambda x: x.has_five)

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -106,13 +106,13 @@ class BlocksYakuChecker(YakuChecker):
 
     # general yaku checker
     @property
-    def is_mixed_same_num_general(self) -> bool:
+    def _is_mixed_same_num(self) -> bool:
         return self.tile_type_count == len(self.blocks) and all(
             self.blocks[0].tile.number == block.tile.number for block in self.blocks
         )
 
     @property
-    def is_pure_chow_general(self) -> bool:
+    def _is_pure_chow(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
             and self.tile_type_count == 1
@@ -120,7 +120,7 @@ class BlocksYakuChecker(YakuChecker):
         )
 
     @property
-    def is_pure_shifted_pungs_general(self) -> bool:
+    def _is_pure_shifted_pungs(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
             and self.tile_type_count == 1
@@ -128,7 +128,7 @@ class BlocksYakuChecker(YakuChecker):
         )
 
     @property
-    def is_pure_shifted_chows_general(self) -> bool:
+    def _is_pure_shifted_chows(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
             and self.tile_type_count == 1
@@ -136,17 +136,17 @@ class BlocksYakuChecker(YakuChecker):
         )
 
     @property
-    def is_big_winds_general(self) -> bool:
+    def _is_big_winds(self) -> bool:
         return self.validate_all_properties(lambda x: x.is_wind, lambda x: x.is_pung)
 
     @property
-    def is_big_dragons_general(self) -> bool:
+    def _is_big_dragons(self) -> bool:
         return self.validate_all_properties(lambda x: x.is_dragon, lambda x: x.is_pung)
 
     # three blocks checker
     @property
     def is_big_three_dragons(self) -> bool:
-        return self.is_big_dragons_general
+        return self._is_big_dragons
 
     @property
     def is_little_three_dragons(self) -> bool:
@@ -158,15 +158,15 @@ class BlocksYakuChecker(YakuChecker):
 
     @property
     def is_pure_triple_chow(self) -> bool:
-        return self.is_pure_chow_general
+        return self._is_pure_chow
 
     @property
     def is_pure_shifted_pungs(self) -> bool:
-        return self.is_pure_shifted_pungs_general
+        return self._is_pure_shifted_pungs
 
     @property
     def is_pure_shifted_chows(self) -> bool:
-        return self.is_pure_shifted_chows_general
+        return self._is_pure_shifted_chows
 
     @property
     def is_pure_straight(self) -> bool:
@@ -189,7 +189,7 @@ class BlocksYakuChecker(YakuChecker):
 
     @property
     def is_big_three_winds(self) -> bool:
-        return self.is_big_winds_general
+        return self._is_big_winds
 
     @property
     def is_knitted_straight(self) -> bool:
@@ -206,7 +206,7 @@ class BlocksYakuChecker(YakuChecker):
     def is_mixed_triple_chow(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and self.is_mixed_same_num_general
+            and self._is_mixed_same_num
         )
 
     @property
@@ -242,18 +242,18 @@ class BlocksYakuChecker(YakuChecker):
     def is_double_pung(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_pung)
-            and self.is_mixed_same_num_general
+            and self._is_mixed_same_num
         )
 
     @property
     def is_pure_double_chow(self) -> bool:
-        return self.is_pure_chow_general
+        return self._is_pure_chow
 
     @property
     def is_mixed_double_chow(self) -> bool:
         return (
             self.validate_all_properties(lambda x: x.is_number, lambda x: x.is_sequence)
-            and self.is_mixed_same_num_general
+            and self._is_mixed_same_num
         )
 
     @property
@@ -275,7 +275,7 @@ class BlocksYakuChecker(YakuChecker):
     # four blocks checker
     @property
     def is_big_four_winds(self) -> bool:
-        return self.is_big_winds_general
+        return self._is_big_winds
 
     @property
     def is_little_four_winds(self) -> bool:
@@ -287,15 +287,15 @@ class BlocksYakuChecker(YakuChecker):
 
     @property
     def is_quadruple_chow(self) -> bool:
-        return self.is_pure_chow_general
+        return self._is_pure_chow
 
     @property
     def is_four_pure_shifted_pungs(self) -> bool:
-        return self.is_pure_shifted_pungs_general
+        return self._is_pure_shifted_pungs
 
     @property
     def is_four_pure_shifted_chows(self) -> bool:
-        return self.is_pure_shifted_chows_general
+        return self._is_pure_shifted_chows
 
     # five blocks checker
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,10 @@ select = [
     "TRY",  # try-except style
 ]
 
-ignore = ["TRY003"] # should be removed
+ignore = [
+    "TRY003",   # should be removed
+    "PLR2004",  # Magic value using in comparision
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 10

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -65,6 +65,20 @@ M111: Final[Block] = Block(BlockType.TRIPLET, Tile.M1)
 M222: Final[Block] = Block(BlockType.TRIPLET, Tile.M2)
 M333: Final[Block] = Block(BlockType.TRIPLET, Tile.M3)
 M4444: Final[Block] = Block(BlockType.QUAD, Tile.M4)
+P111: Final[Block] = Block(BlockType.TRIPLET, Tile.P1)
+P222: Final[Block] = Block(BlockType.TRIPLET, Tile.P2)
+S111: Final[Block] = Block(BlockType.TRIPLET, Tile.S1)
+S333: Final[Block] = Block(BlockType.TRIPLET, Tile.S3)
+Z666: Final[Block] = Block(BlockType.TRIPLET, Tile.Z6)
+Z777: Final[Block] = Block(BlockType.TRIPLET, Tile.Z7)
+Z77: Final[Block] = Block(BlockType.PAIR, Tile.Z7)
+M147: Final[Block] = Block(BlockType.KNITTED, Tile.M1)
+P258: Final[Block] = Block(BlockType.KNITTED, Tile.S2)
+S369: Final[Block] = Block(BlockType.KNITTED, Tile.P3)
+P234: Final[Block] = Block(BlockType.SEQUENCE, Tile.P2)
+S345: Final[Block] = Block(BlockType.SEQUENCE, Tile.S3)
+P456: Final[Block] = Block(BlockType.SEQUENCE, Tile.P4)
+S789: Final[Block] = Block(BlockType.SEQUENCE, Tile.S7)
 
 
 def test_block_yaku_checker():
@@ -92,3 +106,17 @@ def test_block_yaku_checker():
     )
     assert Yaku.FourPureShiftedChows == BlocksYakuChecker([M123, M234, M345, M456]).yaku
     assert Yaku.FourPureShiftedChows == BlocksYakuChecker([M123, M345, M567, M789]).yaku
+
+    assert Yaku.BigThreeDragons == BlocksYakuChecker([Z555, Z666, Z777]).yaku
+    assert Yaku.LittleThreeDragons == BlocksYakuChecker([Z555, Z666, Z77]).yaku
+    assert Yaku.PureTripleChow == BlocksYakuChecker([M123, M123, M123]).yaku
+    assert Yaku.PureShiftedPungs == BlocksYakuChecker([M111, M222, M333]).yaku
+    assert Yaku.PureShiftedChows == BlocksYakuChecker([M123, M234, M345]).yaku
+    assert Yaku.PureStraight == BlocksYakuChecker([M123, M456, M789]).yaku
+    assert Yaku.TriplePung == BlocksYakuChecker([M111, S111, P111]).yaku
+    assert Yaku.BigThreeWinds == BlocksYakuChecker([Z111, Z222, Z333]).yaku
+    assert Yaku.KnittedStraight == BlocksYakuChecker([M147, P258, S369]).yaku
+    assert Yaku.MixedTripleChow == BlocksYakuChecker([M123, P123, S123]).yaku
+    assert Yaku.MixedStraight == BlocksYakuChecker([M123, P456, S789]).yaku
+    assert Yaku.MixedShiftedPungs == BlocksYakuChecker([M111, P222, S333]).yaku
+    assert Yaku.MixedShiftedChows == BlocksYakuChecker([M123, P234, S345]).yaku


### PR DESCRIPTION
3블럭으로 구성된 역 체크 함수를 만들었습니다.

두 번 이상 서로 다른 역에서 활용되는 형태의 검증 로직은 ```..._general```형태의 함수로 분리했습니다.
(e.g. ```is_pure_chow_general```은 일색사동순, 일색삼동순, 희상봉에서 동일하게 사용)

중복되는 로직의 함수를 utils 영역에 추가했습니다.
```
count_blocks_if
has_constant_gap
```

