### PR TITLE
add hand yaku about kong, concealed pungs, number conditions and flush

### DIFF
--- a/app/score_calculator/yaku_check/hand_yaku_checker.py
+++ b/app/score_calculator/yaku_check/hand_yaku_checker.py
@@ -126,8 +126,6 @@ class HandYakuChecker(YakuChecker):
 
     # general yaku checker
     def _count_concealed_pungs(self) -> int:
-        print(self.concealed_tiles)
-        print(self.winning_conditions)
         return self.count_blocks_if(
             lambda x: x.is_pung
             and not x.is_opened


### PR DESCRIPTION
# PR Description

## [1] Hand 판별사항 구현

#16 중 hand와 관련된 판별 사항을 가진 4개의 카테고리의 역들을 구현했습니다.

### 1. 깡
- 사공
- 삼공
- 쌍암공
- 쌍명공
- 암공
- 명공

### 2. 안커
- 사암각
- 삼암각
- 쌍암각

### 3. 숫자 조건
- 자일색
- 청요구
- 혼요구
- 결일문
- 무자

### 4. 일색
- 청일색
- 혼일색
- 결일문

---

## [2] pytest Parameterized Test 개선

`@pytest.mark.parametrize`를 이용해 각 yaku에 대한 테스트를 개선했습니다.  
