### PR TITLE
Add hand shape yakus

### DIFF
--- a/app/score_calculator/block/block.py
+++ b/app/score_calculator/block/block.py
@@ -46,6 +46,10 @@ class Block:
         return self.type == BlockType.PAIR
 
     @property
+    def is_knitted(self) -> bool:
+        return self.type == BlockType.KNITTED
+
+    @property
     def is_number(self) -> bool:
         return self.tile.is_number
 

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -83,13 +83,13 @@ class BlocksYakuChecker(YakuChecker):
         return [block.tile for block in self.blocks]
 
     @cached_property
-    def tile_numbers(self) -> list[int]:
+    def first_tile_numbers(self) -> list[int]:
         return sorted(block.tile.number for block in self.blocks)
 
     def has_constant_gap(self, gap: int) -> bool:
         return all(
             gap == abs(pair[0] - pair[1])
-            for pair in zip(self.tile_numbers, self.tile_numbers[1:])
+            for pair in zip(self.first_tile_numbers, self.first_tile_numbers[1:])
         )
 
     def validate_blocks(self, condition: Callable[[Block], bool]) -> bool:

--- a/app/score_calculator/yaku_check/hand_yaku_checker.py
+++ b/app/score_calculator/yaku_check/hand_yaku_checker.py
@@ -236,7 +236,9 @@ class HandYakuChecker(YakuChecker):
     def _get_hand_shape_conditions(self) -> list[tuple[Callable[[], bool], Yaku]]:
         return [
             (
-                lambda: self.count_blocks_if(lambda b: b.type == BlockType.PAIR) == 7
+                lambda: self.validate_tiles(lambda t: t.is_number)
+                and self.num_tile_types_count == 1
+                and self.count_blocks_if(lambda b: b.type == BlockType.PAIR) == 7
                 and self.has_constant_gap(1),
                 Yaku.SevenShiftedPairs,
             ),
@@ -247,7 +249,8 @@ class HandYakuChecker(YakuChecker):
                     self.tiles[t] >= 3 if t.number in {1, 9} else self.tiles[t] >= 1
                     for t in self.tiles
                 )
-                and self.winning_conditions.count_tenpai_tiles == 9,
+                and self.winning_conditions.count_tenpai_tiles == 9
+                and not self.winning_conditions.is_discarded,
                 Yaku.NineGates,
             ),
             (

--- a/app/score_calculator/yaku_check/hand_yaku_checker.py
+++ b/app/score_calculator/yaku_check/hand_yaku_checker.py
@@ -91,7 +91,12 @@ class HandYakuChecker(YakuChecker):
     @cached_property
     def tiles_by_type(self) -> list[list[int]]:
         return [
-            sorted(tile.number for tile in self.tiles if tile.type == tile_type)
+            sorted(
+                tile.number
+                for tile, count in self.tiles.items()
+                if tile.type == tile_type
+                for _ in range(count)
+            )
             for tile_type in {tile.type for tile in self.tiles}
         ]
 
@@ -236,13 +241,12 @@ class HandYakuChecker(YakuChecker):
                 Yaku.SevenShiftedPairs,
             ),
             (
-                lambda: self.validate_tiles(
-                    lambda t: t.is_number
-                    and (
-                        self.tiles[t] == 3 if t.number in {1, 9} else self.tiles[t] == 1
-                    ),
-                )
+                lambda: self.validate_tiles(lambda t: t.is_number)
                 and self.num_tile_types_count == 1
+                and all(
+                    self.tiles[t] >= 3 if t.number in {1, 9} else self.tiles[t] >= 1
+                    for t in self.tiles
+                )
                 and self.winning_conditions.count_tenpai_tiles == 9,
                 Yaku.NineGates,
             ),

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -206,7 +206,7 @@ def test_concealed_pungs(hand_string, expected_yaku, winning_conditions):
             Yaku.NineGates,
             create_default_winning_conditions(
                 winning_tile=Tile.M5,
-                is_discarded=True,
+                is_discarded=False,
                 count_tenpai_tiles=9,
             ),
             False,

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -192,6 +192,78 @@ def test_concealed_pungs(hand_string, expected_yaku, winning_conditions):
     assert expected_yaku in HandYakuChecker(blocks, winning_conditions).yakus
 
 
+@pytest.mark.parametrize(
+    "hand_string, expected_yaku, winning_conditions, use_seven_pairs",
+    [
+        (
+            "11223344556677m",
+            Yaku.SevenShiftedPairs,
+            create_default_winning_conditions(winning_tile=Tile.M1, is_discarded=True),
+            True,
+        ),
+        (
+            "11112345678999m",
+            Yaku.NineGates,
+            create_default_winning_conditions(
+                winning_tile=Tile.M5,
+                is_discarded=True,
+                count_tenpai_tiles=9,
+            ),
+            False,
+        ),
+        (
+            "123m789m123m789m55m",
+            Yaku.PureTerminalChows,
+            create_default_winning_conditions(winning_tile=Tile.M5, is_discarded=True),
+            False,
+        ),
+        (
+            "222m444p666s888m66p",
+            Yaku.AllEvenPungs,
+            create_default_winning_conditions(winning_tile=Tile.P4, is_discarded=True),
+            False,
+        ),
+        (
+            "11223344667788m",
+            Yaku.SevenPairs,
+            create_default_winning_conditions(winning_tile=Tile.M3, is_discarded=True),
+            True,
+        ),
+        (
+            "123m789m123p789p55s",
+            Yaku.ThreeSuitedTerminalChows,
+            create_default_winning_conditions(winning_tile=Tile.S5, is_discarded=True),
+            False,
+        ),
+        (
+            "222m333p444s555z66p",
+            Yaku.AllPungs,
+            create_default_winning_conditions(winning_tile=Tile.P6, is_discarded=True),
+            False,
+        ),
+        (
+            "123m234m345m456m66m",
+            Yaku.AllChows,
+            create_default_winning_conditions(winning_tile=Tile.M2, is_discarded=True),
+            False,
+        ),
+    ],
+)
+def test_hand_shape_yakus(
+    hand_string,
+    expected_yaku,
+    winning_conditions,
+    use_seven_pairs,
+):
+    hand = raw_string_to_hand_class(hand_string)
+    blocks = (
+        divide_seven_pairs_shape(hand)
+        if use_seven_pairs
+        else divide_general_shape(hand)[0]
+    )
+    assert expected_yaku in HandYakuChecker(blocks, winning_conditions).yakus
+
+
 def test_block_yaku_checker():
     assert [Yaku.MixedDoubleChow] == BlocksYakuChecker([M123, S123]).yakus
     assert [Yaku.PureDoubleChow] == BlocksYakuChecker([M123, M123]).yakus

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -124,12 +124,12 @@ def create_default_winning_conditions(
 )
 def test_hand_yaku_checker(hand_string, expected_yaku, use_seven_pairs):
     hand = raw_string_to_hand_class(hand_string)
-    winning_conditions = create_default_winning_conditions(hand.tiles[-1])
     blocks = (
         divide_seven_pairs_shape(hand)
         if use_seven_pairs
         else divide_general_shape(hand)[0]
     )
+    winning_conditions = create_default_winning_conditions(blocks[0].tile)
     assert expected_yaku in HandYakuChecker(blocks, winning_conditions).yakus
 
 
@@ -143,8 +143,8 @@ def test_hand_yaku_checker(hand_string, expected_yaku, use_seven_pairs):
 )
 def test_hand_yakus_checker_flush(hand_string, expected_yaku):
     hand = raw_string_to_hand_class(hand_string)
-    winning_conditions = create_default_winning_conditions(hand.tiles[-1])
     blocks = divide_general_shape(hand)[0]
+    winning_conditions = create_default_winning_conditions(blocks[0].tile)
     assert expected_yaku in HandYakuChecker(blocks, winning_conditions).yakus
 
 
@@ -161,8 +161,8 @@ def test_hand_yakus_checker_flush(hand_string, expected_yaku):
 )
 def test_hand_yakus_checker_kong(hand_string, expected_yaku):
     hand = raw_string_to_hand_class(hand_string)
-    winning_conditions = create_default_winning_conditions(hand.tiles[-1])
     blocks = divide_general_shape(hand)[0]
+    winning_conditions = create_default_winning_conditions(blocks[0].tile)
     assert expected_yaku in HandYakuChecker(blocks, winning_conditions).yakus
 
 


### PR DESCRIPTION
# PR Description
## [1] Hand Shape 관련 역 판별 구현
#16 중 hand shape와 관련된 판별 사항을 가진 카테고리의 역들을 구현했습니다.

 - 연칠대
 - 구련보등
 - 일색쌍룡회
 - 전쌍각
 - 칠대
 - 삼색쌍룡회
 - 팽팽화
 - 평화

## [2] 역 계산에 필요한 유틸리티 구현
`tiles_by_type, num_tile_types_count` 등 중복되어 사용되는 로직이 있거나 lint상 밖으로 로직을 빼야 하는 경우의 유틸리티 method를 `@cached_property`로 구현하였습니다.

`first_tile_numbers`나 `tiles_by_type`등 block yaku checker와 중복되는 유틸리티는 상위 클래스에서 차후 통합하는 식으로 중복을 제거하는게 나아 보입니다.

그 외에 `lambda` 함수 내부 변수명을 `block`이면 `b`, `tile`이면 `t`로 가독성이 좋게 바꾸는 작업을 하였습니다.

## [3] pytest로 테스트
`@pytest.mark.parametrize`를 이용해 각 `yaku`에 대한 테스트를 하였습니다.