### PR TITLE
GAME-4 add score calculator for general shape

### DIFF
--- a/app/score_calculator/result/result.py
+++ b/app/score_calculator/result/result.py
@@ -37,6 +37,8 @@ class ScoringContext:
                     result += yaku
                     for i in combination:
                         self.used_block_flag[i] = True
+                    if length != 2:
+                        break
         return result
 
     @staticmethod

--- a/app/score_calculator/result/result.py
+++ b/app/score_calculator/result/result.py
@@ -1,37 +1,50 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from itertools import combinations
 
 from app.score_calculator.block.block import Block
 from app.score_calculator.enums.enums import Yaku
-from app.score_calculator.winning_conditions.winning_conditions import WinningConditions
+from app.score_calculator.utility.utility import YAKU_POINT
+from app.score_calculator.yaku_check.blocks_yaku_checker import BlocksYakuChecker
 
 
-@dataclass
+@dataclass(order=True)
 class ScoreResult:
-    yaku_score_list: list[tuple[int, int]]
-    tenpai_tiles: list[int]
-    highest_score: int = 0
-    is_blocks_divided: bool = False
+    total_score: int = field(default=0, compare=True)
+    yaku_score_list: list[tuple[Yaku, int]] = field(default_factory=list, compare=False)
+
+    def add_yaku(self, yaku: Yaku, count: int) -> None:
+        score = YAKU_POINT[yaku] * count
+        self.yaku_score_list.append((yaku, score))
+        self.total_score += score
 
 
 @dataclass
 class ScoringContext:
     blocks: list[Block]
     used_block_flag: list[bool]
-    checked_yaku: dict[Yaku, bool]
-    winning_conditions: WinningConditions
+
+    def get_yakus(self) -> list[Yaku]:
+        result: list[Yaku] = []
+        for length in (4, 3, 2):
+            for combination in combinations(range(4), length):
+                if all(self.used_block_flag[i] for i in combination):
+                    continue
+                if yaku := BlocksYakuChecker(
+                    [self.blocks[i] for i in combination],
+                ).yakus:
+                    result += yaku
+                    for i in combination:
+                        self.used_block_flag[i] = True
+        return result
 
     @staticmethod
-    def create_from_blocks_and_winning_conditions(
+    def create_from_blocks(
         blocks: list[Block],
-        winning_conditions: WinningConditions,
     ) -> ScoringContext:
         used_block_flag: list[bool] = [False] * len(blocks)
-        checked_yaku: dict[Yaku, bool] = {yaku: False for yaku in Yaku}
         return ScoringContext(
             blocks=blocks,
             used_block_flag=used_block_flag,
-            checked_yaku=checked_yaku,
-            winning_conditions=winning_conditions,
         )

--- a/app/score_calculator/score_calculator.py
+++ b/app/score_calculator/score_calculator.py
@@ -1,9 +1,22 @@
 from copy import deepcopy
 
+from app.score_calculator.block.block import Block
+from app.score_calculator.divide.general_shape import divide_general_shape
+from app.score_calculator.enums.enums import BlockType, Yaku
 from app.score_calculator.hand.hand import Hand
-from app.score_calculator.result.result import ScoreResult
+from app.score_calculator.result.result import ScoreResult, ScoringContext
 from app.score_calculator.tenpai_calculator import get_tenpai_tiles
+from app.score_calculator.utility.utility import (
+    EXCLUDED_YAKUS,
+    YAKU_POINT,
+    YAKUS_INCLUDING_PUNG_OF_TOH,
+)
 from app.score_calculator.winning_conditions.winning_conditions import WinningConditions
+from app.score_calculator.yaku_check.blocks_yaku_checker import BlocksYakuChecker
+from app.score_calculator.yaku_check.hand_yaku_checker import HandYakuChecker
+from app.score_calculator.yaku_check.winning_conditions_yaku_checker import (
+    WinningConditionsYakuChecker,
+)
 
 
 class ScoreCalculator:
@@ -17,4 +30,89 @@ class ScoreCalculator:
                 tenpai_hand=tenpai_hand,
             ),
         )
-        self.highest_result = ScoreResult(yaku_score_list=[], tenpai_tiles=[])
+        self.highest_result = ScoreResult(yaku_score_list=[])
+        self.is_blocks_divided = False
+
+    def general_shape_calculator(self) -> None:
+        parsed_hands: list[list[Block]] = divide_general_shape(self.hand)
+        if parsed_hands:
+            self.is_blocks_divided = True
+        for blocks in parsed_hands:
+            score_result = self._calculate_score_result(blocks)
+            self.highest_result = max(self.highest_result, score_result)
+
+    def _calculate_score_result(self, blocks: list[Block]) -> ScoreResult:
+        scoring_context: ScoringContext = ScoringContext.create_from_blocks(
+            blocks=[
+                deepcopy(block) for block in blocks if block.type != BlockType.PAIR
+            ],
+        )
+
+        yaku_list: list[Yaku] = []
+        yaku_list += HandYakuChecker(
+            blocks=deepcopy(blocks),
+            winning_conditions=deepcopy(self.winning_conditions),
+        ).yakus
+        yaku_list += BlocksYakuChecker(blocks=deepcopy(blocks)).yakus
+        yaku_list += scoring_context.get_yakus()
+        yaku_list += WinningConditionsYakuChecker(
+            blocks=deepcopy(blocks),
+            winning_conditions=deepcopy(self.winning_conditions),
+        ).yakus
+
+        yaku_set = self._process_yaku_exclusions(yaku_list)
+
+        score_result: ScoreResult = ScoreResult(yaku_score_list=[])
+        for yaku in yaku_set:
+            score_result.add_yaku(yaku, 1)
+
+        if not (
+            Yaku.SevenPairs in yaku_set
+            and (Yaku.AllTerminals in yaku_set or Yaku.AllGreen in yaku_set)
+        ):
+            score_result.add_yaku(
+                Yaku.TileHog,
+                self.hand.tiles.count(4)
+                - sum(1 for block in self.hand.call_blocks if block.is_quad),
+            )
+
+        pung_count: int = self._count_pung_of_terminals_and_honors(
+            scoring_context,
+            yaku_set,
+        )
+        score_result.add_yaku(Yaku.PungOfTerminalsOrHonors, pung_count)
+        return score_result
+
+    def _process_yaku_exclusions(self, yaku_list: list[Yaku]) -> set[Yaku]:
+        yaku_set = set(yaku_list)
+        yaku_list.sort(key=lambda y: -YAKU_POINT[y])
+        for yaku in yaku_list:
+            if yaku in yaku_set:
+                for excluded_yaku in EXCLUDED_YAKUS[yaku]:
+                    yaku_set.discard(excluded_yaku)
+        return yaku_set
+
+    def _count_pung_of_terminals_and_honors(
+        self,
+        scoring_context: ScoringContext,
+        yaku_set: set[Yaku],
+    ) -> int:
+        count = 0
+        if any(yaku in yaku_set for yaku in YAKUS_INCLUDING_PUNG_OF_TOH):
+            for block in scoring_context.blocks:
+                if not (block.is_outside and block.is_pung):
+                    continue
+                if block.is_dragon or (
+                    block.is_wind
+                    and (
+                        Yaku.LittleFourWinds in yaku_set
+                        or block.tile
+                        in {
+                            self.winning_conditions.round_wind,
+                            self.winning_conditions.seat_wind,
+                        }
+                    )
+                ):
+                    continue
+                count += 1
+        return count

--- a/app/score_calculator/utility/utility.py
+++ b/app/score_calculator/utility/utility.py
@@ -8,6 +8,14 @@ def has_opened_blocks(blocks: list[Block]) -> bool:
     return any(block.is_opened for block in blocks)
 
 
+YAKUS_INCLUDING_PUNG_OF_TOH: Final[set[Yaku]] = {
+    Yaku.BigFourWinds,
+    Yaku.NineGates,
+    Yaku.AllTerminals,
+    Yaku.AllHonors,
+    Yaku.AllTerminalsAndHonors,
+}
+
 EXCLUDED_YAKUS: Final[dict[Yaku, list[Yaku]]] = {
     Yaku.BigFourWinds: [
         Yaku.BigThreeWinds,
@@ -125,7 +133,7 @@ EXCLUDED_YAKUS: Final[dict[Yaku, list[Yaku]]] = {
     Yaku.KnittedStraight: [],
     Yaku.UpperFour: [Yaku.NoHonorTiles],
     Yaku.LowerFour: [Yaku.NoHonorTiles],
-    Yaku.BigThreeWinds: [],  # Yaku.PungOfTerminals~ removed by used block flag
+    Yaku.BigThreeWinds: [],
     Yaku.MixedStraight: [],
     Yaku.ReversibleTiles: [Yaku.OneVoidedSuit],
     Yaku.MixedTripleChow: [],

--- a/app/score_calculator/yaku_check/blocks_yaku_checker.py
+++ b/app/score_calculator/yaku_check/blocks_yaku_checker.py
@@ -24,7 +24,6 @@ class BlocksYakuChecker(YakuChecker):
             ],
             3: [
                 (self.is_big_three_dragons, Yaku.BigThreeDragons),
-                (self.is_little_three_dragons, Yaku.LittleThreeDragons),
                 (self.is_pure_triple_chow, Yaku.PureTripleChow),
                 (self.is_pure_shifted_pungs, Yaku.PureShiftedPungs),
                 (self.is_pure_shifted_chows, Yaku.PureShiftedChows),
@@ -39,7 +38,6 @@ class BlocksYakuChecker(YakuChecker):
             ],
             4: [
                 (self.is_big_four_winds, Yaku.BigFourWinds),
-                (self.is_little_four_winds, Yaku.LittleFourWinds),
                 (self.is_quadruple_chow, Yaku.QuadrupleChow),
                 (self.is_four_pure_shifted_chows, Yaku.FourPureShiftedChows),
                 (self.is_four_pure_shifted_pungs, Yaku.FourPureShiftedPungs),
@@ -47,6 +45,8 @@ class BlocksYakuChecker(YakuChecker):
             5: [
                 (self.is_all_fives, Yaku.AllFives),
                 (self.is_outside_hand, Yaku.OutsideHand),
+                (self.is_little_four_winds, Yaku.LittleFourWinds),
+                (self.is_little_three_dragons, Yaku.LittleThreeDragons),
             ],
         }
         self.set_yakus()
@@ -59,7 +59,14 @@ class BlocksYakuChecker(YakuChecker):
         return self._yakus
 
     def set_yakus(self) -> None:
-        self._yakus = [self.blocks_checker()]
+        if len(self.blocks) == 5:
+            self._yakus = [
+                yaku for checker, yaku in self.conditions[len(self.blocks)] if checker
+            ]
+        else:
+            self._yakus = (
+                [] if (result := self.blocks_checker()) == Yaku.ERROR else [result]
+            )
 
     def blocks_checker(self) -> Yaku:
         if len(self.blocks) not in self.conditions:
@@ -145,9 +152,8 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_little_three_dragons(self) -> bool:
         return (
-            self.validate_blocks(lambda x: x.is_dragon)
-            and self.count_blocks_if(lambda x: x.is_pair) == 1
-            and self.count_blocks_if(lambda x: x.is_pung) == 2
+            self.count_blocks_if(lambda x: x.is_dragon and x.is_pair) == 1
+            and self.count_blocks_if(lambda x: x.is_dragon and x.is_pung) == 2
         )
 
     @property
@@ -267,9 +273,8 @@ class BlocksYakuChecker(YakuChecker):
     @property
     def is_little_four_winds(self) -> bool:
         return (
-            self.validate_blocks(lambda x: x.is_wind)
-            and self.count_blocks_if(lambda x: x.is_pair) == 1
-            and self.count_blocks_if(lambda x: x.is_pung) == 3
+            self.count_blocks_if(lambda x: x.is_wind and x.is_pair) == 1
+            and self.count_blocks_if(lambda x: x.is_wind and x.is_pung) == 3
         )
 
     @property

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -469,7 +469,13 @@ def test_block_yaku_checker():
     assert [Yaku.OutsideHand] == BlocksYakuChecker(blocks).yakus
 
     assert [Yaku.BigFourWinds] == BlocksYakuChecker([Z111, Z222, Z333, Z4444]).yakus
-    assert [Yaku.LittleFourWinds] == BlocksYakuChecker([Z11, Z222, Z333, Z4444]).yakus
+    print(BlocksYakuChecker([Z11, Z222, Z333, Z4444, M111]).yakus)
+    assert (
+        Yaku.LittleFourWinds
+        in BlocksYakuChecker(
+            [Z11, Z222, Z333, Z4444, M111],
+        ).yakus
+    )
     assert [Yaku.QuadrupleChow] == BlocksYakuChecker([M123, M123, M123, M123]).yakus
     assert [Yaku.FourPureShiftedPungs] == BlocksYakuChecker(
         [M111, M222, M333, M4444],
@@ -482,7 +488,12 @@ def test_block_yaku_checker():
     ).yakus
 
     assert [Yaku.BigThreeDragons] == BlocksYakuChecker([Z555, Z666, Z777]).yakus
-    assert [Yaku.LittleThreeDragons] == BlocksYakuChecker([Z555, Z666, Z77]).yakus
+    assert (
+        Yaku.LittleThreeDragons
+        in BlocksYakuChecker(
+            [Z555, Z666, Z77, Z111, Z222],
+        ).yakus
+    )
     assert [Yaku.PureTripleChow] == BlocksYakuChecker([M123, M123, M123]).yakus
     assert [Yaku.PureShiftedPungs] == BlocksYakuChecker([M111, M222, M333]).yakus
     assert [Yaku.PureShiftedChows] == BlocksYakuChecker([M123, M234, M345]).yakus

--- a/tests/test_score_calculator_general.py
+++ b/tests/test_score_calculator_general.py
@@ -1,0 +1,67 @@
+import pytest
+
+from app.score_calculator.enums.enums import Tile, Wind, Yaku
+from app.score_calculator.score_calculator import ScoreCalculator
+from app.score_calculator.winning_conditions.winning_conditions import WinningConditions
+from tests.test_utils import raw_string_to_hand_class
+
+
+def create_default_winning_conditions(
+    winning_tile: Tile,
+    is_discarded: bool = True,
+    count_tenpai_tiles: int = 1,
+    seat_wind: Wind = Wind.EAST,
+    round_wind: Wind = Wind.EAST,
+    **extra_conditions,
+):
+    defaults = {
+        "is_last_tile_in_the_game": False,
+        "is_last_tile_of_its_kind": False,
+        "is_replacement_tile": False,
+        "is_robbing_the_kong": False,
+    }
+    defaults.update(extra_conditions)
+    return WinningConditions(
+        winning_tile=winning_tile,
+        is_discarded=is_discarded,
+        count_tenpai_tiles=count_tenpai_tiles,
+        seat_wind=seat_wind,
+        round_wind=round_wind,
+        is_last_tile_in_the_game=defaults["is_last_tile_in_the_game"],
+        is_last_tile_of_its_kind=defaults["is_last_tile_of_its_kind"],
+        is_replacement_tile=defaults["is_replacement_tile"],
+        is_robbing_the_kong=defaults["is_robbing_the_kong"],
+    )
+
+
+@pytest.mark.parametrize(
+    "hand_string, yaku_score_list, winning_conditions",
+    [
+        (
+            "66m111222333444z",
+            [
+                (Yaku.BigFourWinds, 88),
+                (Yaku.FourConcealedPungs, 64),
+                (Yaku.HalfFlush, 6),
+                (Yaku.SingleWait, 1),
+            ],
+            create_default_winning_conditions(winning_tile=Tile.M6, is_discarded=True),
+        ),
+        (
+            "11999m111p111999s",
+            [
+                (Yaku.FourConcealedPungs, 64),
+                (Yaku.AllTerminals, 64),
+                (Yaku.DoublePung, 4),
+                (Yaku.SingleWait, 1),
+            ],
+            create_default_winning_conditions(winning_tile=Tile.M1, is_discarded=True),
+        ),
+    ],
+)
+def test_tenpai_tiles_checker(hand_string, yaku_score_list, winning_conditions):
+    hand = raw_string_to_hand_class(hand_string)
+    sc = ScoreCalculator(hand, winning_conditions=winning_conditions)
+    sc.general_shape_calculator()
+    print(sc.highest_result.yaku_score_list)
+    assert set(sc.highest_result.yaku_score_list) == set(yaku_score_list)

--- a/tests/test_score_calculator_general.py
+++ b/tests/test_score_calculator_general.py
@@ -57,6 +57,27 @@ def create_default_winning_conditions(
             ],
             create_default_winning_conditions(winning_tile=Tile.M1, is_discarded=True),
         ),
+        (
+            "12223456567789p",
+            [
+                (Yaku.FullFlush, 24),
+                (Yaku.PureStraight, 16),
+                (Yaku.ConcealedHand, 2),
+                (Yaku.AllChows, 2),
+                (Yaku.ClosedWait, 1),
+            ],
+            create_default_winning_conditions(winning_tile=Tile.P2, is_discarded=True),
+        ),
+        (
+            "123m234s345p456m77z",
+            [
+                (Yaku.MixedShiftedChows, 6),
+                (Yaku.ConcealedHand, 2),
+                (Yaku.ShortStraight, 1),
+                (Yaku.SingleWait, 1),
+            ],
+            create_default_winning_conditions(winning_tile=Tile.Z7, is_discarded=True),
+        ),
     ],
 )
 def test_tenpai_tiles_checker(hand_string, yaku_score_list, winning_conditions):


### PR DESCRIPTION
[![GAME-4](https://badgen.net/badge/JIRA/GAME-4/0052CC)](https://mcrs.atlassian.net/browse/GAME-4) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

일반형에 대한 점수 계산을 구현하였습니다.

## result.py
먼저, 계산 결과를 저장하는 calss ScoreResult와 점수 계산 과정에서 생기는 context를 저장하는 class ScoringContext가 기존에 설계했던 것과 필요한 내용이 달라져서 수정했습니다.
ScoringContext는 Block들의 관계로 생성되는 역들의 점수 계산에만 관여하게 됐는데, 이름을 바꾸는게 나을지도 모르겠네요.

## utility.py
요구각에 대한 예외처리를 위해 상위역에 대한 set을 만들었습니다

## blocks_yaku_checker.py
현 로직에서 Pair 조건도 있는 소사희와 소삼원은 blocks yaku checker에서 예외처리 하였습니다.

## score_calculator.py
- general_shape_calculator
현재 일반형만 구현하였습니다, 치또이는 바로 현 코드에 결합가능하고, 불고와 국사는 따로 역 검증 코드를 짜야 합니다.
역을 전부 구하고, 예외처리 역들을 제외하고, 사귀일과 요구각에 대한 특수 예외처리를 하였습니다.
- _calculate_score_result
- _process_yaku_exclusions
   - _count_pung_of_terminals_and_honors

[GAME-4]: https://mcrs.atlassian.net/browse/GAME-4?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ