### PR TITLE
GAME-30 WebSocket 메시지 스키마 통합 구현

### DIFF
--- a/app/schemas/game_ws_message.py
+++ b/app/schemas/game_ws_message.py
@@ -1,13 +1,11 @@
 from typing import Any, Literal
 
 from pydantic import BaseModel
-from services.score_calculator.enums.enums import Wind, Yaku
 
+# 밑은 예시이고 변경가능
 ActionType = Literal[
     "authenticateRequest",
     "authenticateResponse",
-    "scoreCheckRequest",
-    "scoreCheckResponse",
 ]
 
 
@@ -19,57 +17,25 @@ class BaseGameWebSocketMessage(BaseModel):
         extra = "forbid"
 
 
-class AuthenticateData(BaseModel):
+class AuthenticateRequestData(BaseModel):
     access_token: str
-    client_id: str
+    client_uid: str
 
 
 class AuthenticateResponseData(BaseModel):
     success: bool
     message: str
-    client_id: str | None
+    client_uid: str | None
 
 
-class ScoreCheckData(BaseModel):
-    hand: str
-    winning_tile: str
-    is_discarded: bool
-    seat_wind: Wind
-    round_wind: Wind
-    is_last_tile_in_the_game: bool
-    is_last_tile_of_its_kind: bool
-    is_replacement_tile: bool
-    is_robbing_the_kong: bool
-
-
-class ScoreCheckResponseData(BaseModel):
-    total_score: int
-    yaku_score_list: list[tuple[Yaku, int]]
-
-
-class AuthenticateRequestMessage(BaseGameWebSocketMessage):
+class AuthenticateRequest(BaseGameWebSocketMessage):
     action: Literal["authenticateRequest"]
-    data: AuthenticateData
+    data: AuthenticateRequestData
 
 
-class AuthenticateResponseMessage(BaseGameWebSocketMessage):
+class AuthenticateResponse(BaseGameWebSocketMessage):
     action: Literal["authenticateResponse"]
     data: AuthenticateResponseData
 
 
-class ScoreCheckRequestMessage(BaseGameWebSocketMessage):
-    action: Literal["scoreCheckRequest"]
-    data: ScoreCheckData
-
-
-class ScoreCheckResponseMessage(BaseGameWebSocketMessage):
-    action: Literal["scoreCheckRequest"]
-    data: ScoreCheckResponseData
-
-
-GameWebSocketMessage = (
-    AuthenticateRequestMessage
-    | AuthenticateResponseMessage
-    | ScoreCheckRequestMessage
-    | ScoreCheckResponseMessage
-)
+GameWebSocketMessage = AuthenticateRequest | AuthenticateResponse

--- a/app/schemas/game_ws_message.py
+++ b/app/schemas/game_ws_message.py
@@ -1,0 +1,75 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel
+from services.score_calculator.enums.enums import Wind, Yaku
+
+ActionType = Literal[
+    "authenticateRequest",
+    "authenticateResponse",
+    "scoreCheckRequest",
+    "scoreCheckResponse",
+]
+
+
+class BaseGameWebSocketMessage(BaseModel):
+    action: ActionType
+    data: dict[str, Any]
+
+    class Config:
+        extra = "forbid"
+
+
+class AuthenticateData(BaseModel):
+    access_token: str
+    client_id: str
+
+
+class AuthenticateResponseData(BaseModel):
+    success: bool
+    message: str
+    client_id: str | None
+
+
+class ScoreCheckData(BaseModel):
+    hand: str
+    winning_tile: str
+    is_discarded: bool
+    seat_wind: Wind
+    round_wind: Wind
+    is_last_tile_in_the_game: bool
+    is_last_tile_of_its_kind: bool
+    is_replacement_tile: bool
+    is_robbing_the_kong: bool
+
+
+class ScoreCheckResponseData(BaseModel):
+    total_score: int
+    yaku_score_list: list[tuple[Yaku, int]]
+
+
+class AuthenticateRequestMessage(BaseGameWebSocketMessage):
+    action: Literal["authenticateRequest"]
+    data: AuthenticateData
+
+
+class AuthenticateResponseMessage(BaseGameWebSocketMessage):
+    action: Literal["authenticateResponse"]
+    data: AuthenticateResponseData
+
+
+class ScoreCheckRequestMessage(BaseGameWebSocketMessage):
+    action: Literal["scoreCheckRequest"]
+    data: ScoreCheckData
+
+
+class ScoreCheckResponseMessage(BaseGameWebSocketMessage):
+    action: Literal["scoreCheckRequest"]
+    data: ScoreCheckResponseData
+
+
+GameWebSocketMessage = (
+    AuthenticateRequestMessage
+    | AuthenticateResponseMessage
+    | ScoreCheckRequestMessage
+    | ScoreCheckResponseMessage
+)


### PR DESCRIPTION
[![GAME-30](https://badgen.net/badge/JIRA/GAME-30/0052CC)](https://mcrs.atlassian.net/browse/GAME-30) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# PR 설명

이 PR은 게임 서버와 클라이언트 간 WebSocket 통신에 사용되는 메시지 구조를 통합적으로 관리하기 위해 새로운 스키마 파일(`game_ws_message.py`)을 추가합니다.

## 주요 변경 사항

- **기본 메시지 모델(BaseGameWebSocketMessage) 추가**  
  - `action`과 `data` 필드를 갖도록 정의하여 모든 WebSocket 메시지가 동일한 기본 구조를 따르게 합니다.
  - `extra = "forbid"` 옵션을 사용하여, 정의되지 않은 필드가 포함되면 검증 오류를 발생시켜 데이터 무결성을 보장합니다.

- **요청/응답 구분을 위한 액션 타입 정의**  
  - 액션 타입에 "authenticateRequest", "authenticateResponse" 를 사용하여 메시지의 역할(클라이언트 요청 vs 서버 응답)을 명확히 구분합니다.

- **액션별 데이터 모델 정의**  
  - **인증 관련:**  
    - `AuthenticateData` 모델: 클라이언트가 전송할 토큰과 클라이언트 ID 정보를 포함합니다.
    - `AuthenticateResponseData` 모델: 서버가 인증 결과를 응답할 때, 성공 여부와 메시지, 인증된 클라이언트 ID 정보를 포함합니다.
    - Core Sever에서 넘겨주는 방식으로 바뀌면 그에 대응할 예정입니다. 일단 schema 정의를 위해 임시로 정의하였습니다.

- **Union 타입을 사용한 통합**  
  - 최종적으로 `GameWebSocketMessage` 타입을 파이프(`|`) 연산자를 사용해 여러 메시지 모델(AuthenticateRequestMessage, AuthenticateResponseMessage)을 하나의 Union으로 통합하여, 들어오는 메시지의 `action` 값에 따라 자동으로 올바른 모델로 파싱 및 검증할 수 있도록 했습니다.

## 기대 효과

- **데이터 구조 및 확장성:**  
  - Pydantic을 이용한 기본 데이터 구조 기능을 활용하여 잘못된 데이터가 서버로 전달되는 것을 방지하였습니다
- **서버/클라이언트 메시지 역할 명확화:**  
  - Request/Response를 명시적으로 구분하여, 서버와 클라이언트 간 통신 흐름을 보다 명확하게 하여 유지보수할 수 있습니다.
- **유연한 확장성:**  
  - 추가적인 Evnet/Action에 따른 액션 타입이나 데이터 모델이 필요한 경우, 동일한 패턴으로 쉽게 확장할 수 있습니다.

[GAME-30]: https://mcrs.atlassian.net/browse/GAME-30?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ