### PR TITLE
GAME-15 add game start init method

### DIFF
--- a/app/services/game_manager/models/player.py
+++ b/app/services/game_manager/models/player.py
@@ -1,4 +1,8 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+
+from pydantic import BaseModel
 
 
 # 필요한 필드 추후 추가
@@ -7,3 +11,15 @@ class Player:
     uid: str
     index: int
     score: int
+
+    @staticmethod
+    def create_from_received_data(
+        player_data: PlayerDataReceived,
+        index: int,
+    ) -> Player:
+        return Player(uid=player_data.uid, index=index, score=0)
+
+
+# Core Server에서 넘어오는 정보에 따라 필드 추후 추가, api 구현시 schema로 이동
+class PlayerDataReceived(BaseModel):
+    uid: str


### PR DESCRIPTION
[![GAME-15](https://badgen.net/badge/JIRA/GAME-15/0052CC)](https://mcrs.atlassian.net/browse/GAME-15) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

GameManger에서 게임 시작시 init method를 구현했습니다.

Player class의 field에 어떤 것들이 들어갈지는 Core Server에서 넘어오는 정보에 따라 달라지기에, 추후 필드를 추가하고 나서 schemas로 옮길 수 있도록 PlayerDataReceived class를 pydantic BaseModel로 만들었습니다.

roundmanager와 gamemanager의 구조를 약간 바꾸었습니다.

[GAME-15]: https://mcrs.atlassian.net/browse/GAME-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ