### PR TITLE
GAME-20: Implement tsumo function and refactor files

### DIFF
--- a/app/services/game_manager/models/action.py
+++ b/app/services/game_manager/models/action.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
-from app.services.game_manager.models.enums import ActionType, RelativeSeat
+from app.services.game_manager.models.enums import RelativeSeat
+from app.services.game_manager.models.types import ActionType
 
 
 @dataclass(order=True)

--- a/app/services/game_manager/models/call_block.py
+++ b/app/services/game_manager/models/call_block.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
-from app.services.game_manager.models.enums import CallBlockType, GameTile, RelativeSeat
+from app.services.game_manager.models.enums import GameTile, RelativeSeat
+from app.services.game_manager.models.types import CallBlockType
 
 
 @dataclass

--- a/app/services/game_manager/models/deck.py
+++ b/app/services/game_manager/models/deck.py
@@ -27,11 +27,11 @@ class Deck:
             self.tiles[i], self.tiles[j] = self.tiles[j], self.tiles[i]
 
     @property
-    def tiles_left(self) -> int:
+    def tiles_remaining(self) -> int:
         return self.draw_index_right - self.draw_index_left
 
     def draw_tiles(self, count: int) -> list[GameTile] | None:
-        remaining: int = self.tiles_left
+        remaining: int = self.tiles_remaining
         if remaining < count:
             return None
         drawn_tiles: list[GameTile] = self.tiles[
@@ -41,7 +41,7 @@ class Deck:
         return drawn_tiles
 
     def draw_tiles_right(self, count: int) -> list[GameTile] | None:
-        remaining: int = self.tiles_left
+        remaining: int = self.tiles_remaining
         if remaining < count:
             return None
         drawn_tiles: list[GameTile] = self.tiles[

--- a/app/services/game_manager/models/deck.py
+++ b/app/services/game_manager/models/deck.py
@@ -26,8 +26,12 @@ class Deck:
             j = randbelow(i + 1)
             self.tiles[i], self.tiles[j] = self.tiles[j], self.tiles[i]
 
+    @property
+    def tiles_left(self) -> int:
+        return self.draw_index_right - self.draw_index_left
+
     def draw_tiles(self, count: int) -> list[GameTile] | None:
-        remaining: int = self.draw_index_right - self.draw_index_left
+        remaining: int = self.tiles_left
         if remaining < count:
             return None
         drawn_tiles: list[GameTile] = self.tiles[
@@ -37,7 +41,7 @@ class Deck:
         return drawn_tiles
 
     def draw_tiles_right(self, count: int) -> list[GameTile] | None:
-        remaining: int = self.draw_index_right - self.draw_index_left
+        remaining: int = self.tiles_left
         if remaining < count:
             return None
         drawn_tiles: list[GameTile] = self.tiles[

--- a/app/services/game_manager/models/deck.py
+++ b/app/services/game_manager/models/deck.py
@@ -30,20 +30,26 @@ class Deck:
     def tiles_remaining(self) -> int:
         return self.draw_index_right - self.draw_index_left
 
-    def draw_tiles(self, count: int) -> list[GameTile] | None:
+    def draw_tiles(self, count: int) -> list[GameTile]:
         remaining: int = self.tiles_remaining
         if remaining < count:
-            return None
+            raise ValueError(
+                "Not enough tiles remaining. Requested: "
+                "{count}, Available: {remaining}",
+            )
         drawn_tiles: list[GameTile] = self.tiles[
             self.draw_index_left : self.draw_index_left + count
         ]
         self.draw_index_left += count
         return drawn_tiles
 
-    def draw_tiles_right(self, count: int) -> list[GameTile] | None:
+    def draw_tiles_right(self, count: int) -> list[GameTile]:
         remaining: int = self.tiles_remaining
         if remaining < count:
-            return None
+            raise ValueError(
+                "Not enough tiles remaining. Requested: "
+                "{count}, Available: {remaining}",
+            )
         drawn_tiles: list[GameTile] = self.tiles[
             self.draw_index_right - count : self.draw_index_right
         ]
@@ -51,7 +57,9 @@ class Deck:
         return drawn_tiles
 
     def draw_haipai(self) -> list[GameTile]:
-        tiles = self.draw_tiles(Deck.HAIPAI_TILES)
-        if tiles is None:
-            raise ValueError("Not enough tiles in the deck to draw haipai")
-        return tiles
+        if self.tiles_remaining < Deck.HAIPAI_TILES:
+            raise ValueError(
+                "Not enough tiles in the deck to draw haipai. Requested: "
+                "{Deck.HAIPAI_TILES}, Available: {self.tiles_remaining}",
+            )
+        return self.draw_tiles(Deck.HAIPAI_TILES)

--- a/app/services/game_manager/models/enums.py
+++ b/app/services/game_manager/models/enums.py
@@ -1,4 +1,10 @@
+from __future__ import annotations
+
 from enum import IntEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from app.services.game_manager.models.action import Action
 
 
 class Round(IntEnum):
@@ -25,28 +31,18 @@ class Round(IntEnum):
     END = 16
 
 
-class ActionType(IntEnum):
-    SKIP = 0
-    HU = 1
-    KAN = 2
-    PON = 3
-    CHII = 4
-    FLOWER = 5
-
-
-class CallBlockType(IntEnum):
-    CHII = 0
-    PUNG = 1
-    AN_KONG = 2
-    SHOMIN_KONG = 3
-    DAIMIN_KONG = 4
-
-
-class Wind(IntEnum):
+class AbsoluteSeat(IntEnum):
     EAST = 0
     SOUTH = 1
     WEST = 2
     NORTH = 3
+
+    @property
+    def next_seat(self) -> AbsoluteSeat:
+        return AbsoluteSeat((self + 1) % 4)
+
+    def next_seat_after_action(self, action: Action) -> AbsoluteSeat:
+        return AbsoluteSeat((self + action.seat_priority) % 4)
 
 
 class RelativeSeat(IntEnum):

--- a/app/services/game_manager/models/hand.py
+++ b/app/services/game_manager/models/hand.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from typing import Final
 
 from app.services.game_manager.models.call_block import CallBlock
-from app.services.game_manager.models.enums import CallBlockType, GameTile
+from app.services.game_manager.models.enums import GameTile
+from app.services.game_manager.models.types import CallBlockType
 
 
 @dataclass

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -151,7 +151,10 @@ class RoundManager:
         # TODO: Discard 후 Action 확인 로직 구현
         return []
 
-    def send_discard_actions_and_wait(self, actions_lists: list[list[Action]]) -> None:
+    def call_discard_actions_and_wait_api(
+        self,
+        actions_lists: list[list[Action]],
+    ) -> None:
         """
         Discard 후 Action들을 플레이어에게 전송하고 응답을 대기
 
@@ -201,7 +204,10 @@ class RoundManager:
         return []
 
     # TODO
-    def send_tsumo_actions_and_wait(self, actions_lists: list[list[Action]]) -> None:
+    def call_send_tsumo_actions_and_wait_api(
+        self,
+        actions_lists: list[list[Action]],
+    ) -> None:
         """
         Tsumo 후 수행 가능한 Action list 플레이어에게 전송하고 응답을 대기
 
@@ -264,7 +270,7 @@ class RoundManager:
             previous_turn_type=previous_turn_type,
         )
         actions_lists: list[list[Action]] = self.check_actions_after_tsumo()
-        self.send_tsumo_actions_and_wait(actions_lists=actions_lists)
+        self.call_send_tsumo_actions_and_wait_api(actions_lists=actions_lists)
 
 
 class GameManager:

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -29,7 +29,7 @@ class RoundManager:
     Game의 한 국(Round)의 로직을 관리하는 Class
 
     Attributes:
-        game_manager (GameManager): GameManager에 대한 참조. end_round에 대한
+        game_manager (GameManager): GameManager에 대한 참조 end_round에 대한
             정보를 주거나, action_id를 받아오기 위함
         tile_deck (Deck): 패산
         hand_list (list[GameHand]): 각 플레이어(절대 위치 자리(동가, 남가, 서가, 북가))
@@ -102,7 +102,7 @@ class RoundManager:
         previous_action: Action | None = None,
     ) -> None:
         """
-        이전 TurnType과 수행한 Action에 따라 다음 턴으로 진행합니다.
+        이전 TurnType과 수행한 Action에 따라 다음 턴으로 진행함
 
         Args:
             previous_turn_type (TurnType): 이전 턴의 타입
@@ -222,7 +222,7 @@ class RoundManager:
         previous_turn_type: TurnType,
     ) -> None:
         """
-        현재 포커싱된 화료패 후보와 이전 TurnType에 따라 WinningCondition을 설정합니다.
+        현재 포커싱된 화료패 후보와 이전 TurnType에 따라 WinningCondition을 설정함
 
         Args:
             winning_tile (GameTile): 화료패 후보
@@ -243,9 +243,9 @@ class RoundManager:
 
     def do_tsumo(self, previous_turn_type: TurnType) -> None:
         """
-        현재 플레이어의 Tsumo 액션을 수행한다.
+        현재 플레이어의 Tsumo 액션을 수행함
 
-        이전 TurnType에 따라 패산의 왼쪽 또는 오른쪽에서 타일을 뽑음. 뽑은 타일을
+        이전 TurnType에 따라 패산의 왼쪽 또는 오른쪽에서 타일을 뽑음 뽑은 타일을
         현재 플레이어의 손패에 추가하고, Winning Condition을 설정한 후 가능한 action
         list들을 확인하고 플레이어에게 전송
 

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -257,6 +257,11 @@ class RoundManager:
             previous_turn_type (TurnType): 이전 턴의 타입
         """
         drawn_tiles: list[GameTile] | None
+        if self.tile_deck.HAIPAI_TILES < 1:
+            raise ValueError(
+                "Not enough tiles remaining. "
+                "Requested: {1}, Available: {self.tile_deck.HAIPAI_TILES}",
+            )
         if previous_turn_type.is_next_replacement:
             drawn_tiles = self.tile_deck.draw_tiles_right(1)
         else:

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -33,7 +33,8 @@ class RoundManager:
             정보를 주거나, action_id를 받아오기 위함
         tile_deck (Deck): 패산
         hand_list (list[GameHand]): 각 플레이어(절대 위치 자리(동가, 남가, 서가, 북가))
-        의 손패 리스트kawa_list (list[list[GameTile]]): 각 플레이어의 강
+        의 손패 리스트
+        kawa_list (list[list[GameTile]]): 각 플레이어의 강
         visible_tiles_count (Counter[GameTile]): 보이는 타일의 개수를 관리하는 카운터
             (화절장 조건을 알기 위해 존재)
         winning_conditions (GameWinningConditions): 화료 조건 flag들

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -114,12 +114,7 @@ class RoundManager:
             ValueError: 다음 턴 타입이 유효하지 않을 경우. (next_seat_after_action의
                 현재 구조상 도달할 수 없으나 이후 해당함수의 변경에 대비해 설정)
         """
-        if previous_turn_type == TurnType.DISCARD:
-            self.current_player_seat = self.current_player_seat.next_seat
-        elif previous_action is not None:
-            self.current_player_seat = self.current_player_seat.next_seat_after_action(
-                action=previous_action,
-            )
+        self.move_current_player_seat_to_next(previous_action=previous_action)
         match previous_turn_type.next_turn:
             case TurnType.TSUMO:
                 self.do_tsumo(previous_turn_type=previous_turn_type)

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -316,9 +316,6 @@ class GameManager:
         self.action_id = 0
 
     def increase_action_id(self) -> None:
-        """
-        action_id를 1 증가
-        """
         self.action_id += 1
 
 

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -236,7 +236,7 @@ class RoundManager:
             self.visible_tiles_count.get(winning_tile, 0) == 3
         )
         self.winning_conditions.is_last_tile_in_the_game = (
-            self.tile_deck.tiles_left == 0
+            self.tile_deck.tiles_remaining == 0
         )
         self.winning_conditions.is_replacement_tile = previous_turn_type.is_kong
         self.winning_conditions.is_robbing_the_kong = (

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -250,6 +250,8 @@ class RoundManager:
         이전 TurnType에 따라 패산의 왼쪽 또는 오른쪽에서 타일을 뽑음 뽑은 타일을
         현재 플레이어의 손패에 추가하고, Winning Condition을 설정한 후 가능한 action
         list들을 확인하고 플레이어에게 전송
+        is_next_replacement일 경우 tile_deck.tiles_left > 0 인 상황에서 previous
+            action이 실행됨이 이 함수 외부에서 보장되어야 함
 
         Args:
             previous_turn_type (TurnType): 이전 턴의 타입

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -7,33 +7,268 @@ from typing import Final
 
 from app.services.game_manager.models.action import Action
 from app.services.game_manager.models.deck import Deck
-from app.services.game_manager.models.enums import GameTile, RelativeSeat, Round, Wind
+from app.services.game_manager.models.enums import (
+    AbsoluteSeat,
+    GameTile,
+    RelativeSeat,
+    Round,
+)
 from app.services.game_manager.models.hand import GameHand
-from app.services.game_manager.models.player import Player, PlayerDataReceived
-from app.services.game_manager.models.winning_conditions import GameWinningConditions
+from app.services.game_manager.models.player import (
+    Player,
+    PlayerDataReceived,
+)
+from app.services.game_manager.models.types import TurnType
+from app.services.game_manager.models.winning_conditions import (
+    GameWinningConditions,
+)
 
 
 class RoundManager:
+    """
+    Game의 한 국(Round)의 로직을 관리하는 Class
+
+    Attributes:
+        game_manager (GameManager): GameManager에 대한 참조. end_round에 대한
+            정보를 주거나, action_id를 받아오기 위함
+        tile_deck (Deck): 패산
+        hand_list (list[GameHand]): 각 플레이어(절대 위치 자리(동가, 남가, 서가, 북가))
+        의 손패 리스트kawa_list (list[list[GameTile]]): 각 플레이어의 강
+        visible_tiles_count (Counter[GameTile]): 보이는 타일의 개수를 관리하는 카운터
+            (화절장 조건을 알기 위해 존재)
+        winning_conditions (GameWinningConditions): 화료 조건 flag들
+        seat_to_player_index (dict[AbsoluteSeat, int]): 절대 좌표와 player index의 매핑
+            (e.g. game_manager.players_list[seat_to_player_index[current_player_seat]])
+        action_manager (ActionManager | None): Action 우선순위를 heap으로 관리하여 실행
+            Action을 결정하는 manager
+        current_player_seat (AbsoluteSeat): 현재 턴이 수행되고 있는 플레이어의 절대 위치
+            자리
+    """
+
     def __init__(self, game_manager: GameManager) -> None:
+        """
+        RoundManager 인스턴스를 초기화
+
+        Args:
+            game_manager (GameManager): 이 Round를 소유하는 GameManager
+        """
         self.game_manager: GameManager = game_manager
         self.tile_deck: Deck
         self.hand_list: list[GameHand]
         self.kawa_list: list[list[GameTile]]
         self.visible_tiles_count: Counter[GameTile]
         self.winning_conditions: GameWinningConditions
-        self.wind_to_player_index: dict[Wind, int] = {}
+        self.seat_to_player_index: dict[AbsoluteSeat, int] = {}
         self.action_manager: ActionManager | None
+        self.current_player_seat: AbsoluteSeat
 
     def init_round(self) -> None:
+        """
+        round 초기화를 수행
+
+        패산, 손패, default Winning Condition 등 Round에 필요한 기본 데이터들을 설정
+        """
         self.tile_deck = Deck()
         self.hand_list = [
-            GameHand.create_from_tiles(self.tile_deck.draw_haipai())
+            GameHand.create_from_tiles(tiles=self.tile_deck.draw_haipai())
             for _ in range(GameManager.MAX_PLAYERS)
         ]
         self.kawa_list = [[] for _ in range(GameManager.MAX_PLAYERS)]
         self.visible_tiles_count = Counter()
         self.winning_conditions = GameWinningConditions.create_default_conditions()
         self.action_manager = None
+        self.current_player_seat = AbsoluteSeat.EAST
+
+    def start_round(self) -> None:
+        """
+        Round의 진입점
+
+        배패의 화패를 빼는것으로부터 시작
+        """
+        self.do_flower_action_in_init_hand()
+
+    # TODO
+    def do_flower_action_in_init_hand(self) -> None:
+        """
+        배패의 화패를 동->남->서->북 순으로 전부 빼는 함수
+
+        이후 self.do_tsumo()로 진입
+        """
+        pass
+
+    def proceed_next_turn(
+        self,
+        previous_turn_type: TurnType,
+        previous_action: Action | None = None,
+    ) -> None:
+        """
+        이전 TurnType과 수행한 Action에 따라 다음 턴으로 진행합니다.
+
+        Args:
+            previous_turn_type (TurnType): 이전 턴의 타입
+            previous_action (Action | None): 이전 턴에서 수행한 액션 (없을 수도 있음
+                (e.g. Discard의 경우 Action class에 속하지 않음))
+
+        Raises:
+            ValueError: 다음 턴 타입이 유효하지 않을 경우. (next_seat_after_action의
+                현재 구조상 도달할 수 없으나 이후 해당함수의 변경에 대비해 설정)
+        """
+        if previous_turn_type == TurnType.DISCARD:
+            self.current_player_seat = self.current_player_seat.next_seat
+        elif previous_action is not None:
+            self.current_player_seat = self.current_player_seat.next_seat_after_action(
+                action=previous_action,
+            )
+        match previous_turn_type.next_turn:
+            case TurnType.TSUMO:
+                self.do_tsumo(previous_turn_type=previous_turn_type)
+            case TurnType.DISCARD:
+                self.do_discard(previous_turn_type=previous_turn_type)
+            case _:
+                raise ValueError(
+                    "[RoundManager.proceed_next_turn] Invalid next turn type.",
+                )
+
+    def do_discard(self, previous_turn_type: TurnType) -> None:
+        """
+        현재 턴에 Discard를 수행
+
+        이 메서드는 추후 구현되어야 함
+
+        Args:
+            previous_turn_type (TurnType): 이전 턴의 타입
+        """
+        # TODO: Discard 로직 구현, 이후 check_action_after_discard로 진입
+        pass
+
+    def check_actions_after_discard(self) -> list[list[Action]]:
+        """
+        Discard 후 가능한 Action들을 확인
+
+        이 메서드는 추후 구현되어야 함
+
+        Returns:
+            list[list[Action]]: Discard 후 가능한 Action들의 플레이어별 list,
+            lst[player_absolute_seat_index]로 해당 플레이어의 Action list에
+            접근가능
+        """
+        # TODO: Discard 후 Action 확인 로직 구현
+        return []
+
+    def send_discard_actions_and_wait(self, actions_lists: list[list[Action]]) -> None:
+        """
+        Discard 후 Action들을 플레이어에게 전송하고 응답을 대기
+
+        이 메서드는 추후 구현되어야 함
+        """
+        # TODO: Discard와 그에 따른 Action list 전송 및 Action 선택 대기 로직 구현
+        # Discard에 따른 Action은 timeout후 강제 진행을 고려해줘야 함
+        pass
+
+    def move_current_player_seat_to_next(
+        self,
+        previous_action: Action | None = None,
+    ) -> None:
+        """
+        현재 턴이 수행되고 있는 절대 자리를 다음 턴이 수행될 자리로 이동시킴
+
+        Args:
+            previous_action (Action | None): 이전 액션 (None이면 Discard). Action이
+            수행되었다면 Action의 상대 좌표에 따라 포커싱하고 있는 자리 이동
+        """
+        if previous_action is None:
+            self.current_player_seat = self.current_player_seat.next_seat
+        else:
+            self.current_player_seat = self.current_player_seat.next_seat_after_action(
+                action=previous_action,
+            )
+
+    def end_round_as_draw(self) -> None:
+        """
+        Round를 유국으로 종료
+
+        이 메서드는 추후 구현되어야 함
+        """
+        # TODO: 유국 처리 로직 구현
+        pass
+
+    # TODO
+    def check_actions_after_tsumo(self) -> list[list[Action]]:
+        """
+        Tsumo 후 가능한 Action들을 확인합니다.
+
+        Returns:
+            list[list[Action]]: Tsumo 후 가능한 Action들의 플레이어별 list,
+            lst[player_absolute_seat_index]로 해당 플레이어의 Action list에 접근가능
+        """
+        # TODO: Tsumo 후 Action 확인 로직 구현
+        return []
+
+    # TODO
+    def send_tsumo_actions_and_wait(self, actions_lists: list[list[Action]]) -> None:
+        """
+        Tsumo 후 수행 가능한 Action list 플레이어에게 전송하고 응답을 대기
+
+        이 메서드는 추후 구현되어야 함
+        """
+        # TODO: Tsumo와 수행 가능한 Action 전송 및 대기 로직 구현
+        # Discard와는 다르게 강제 진행하지 않아도 됨(타패 타이머와 Time을 공유하며
+        # action wait에 대한 timeout은 별도로 없음)
+        pass
+
+    def set_winning_conditions(
+        self,
+        winning_tile: GameTile,
+        previous_turn_type: TurnType,
+    ) -> None:
+        """
+        현재 포커싱된 화료패 후보와 이전 TurnType에 따라 WinningCondition을 설정합니다.
+
+        Args:
+            winning_tile (GameTile): 화료패 후보
+            previous_turn_type (TurnType): 이전 턴의 타입
+        """
+        self.winning_conditions.winning_tile = winning_tile
+        self.winning_conditions.is_discarded = previous_turn_type.is_next_discard
+        self.winning_conditions.is_last_tile_of_its_kind = (
+            self.visible_tiles_count.get(winning_tile, 0) == 3
+        )
+        self.winning_conditions.is_last_tile_in_the_game = (
+            self.tile_deck.tiles_left == 0
+        )
+        self.winning_conditions.is_replacement_tile = previous_turn_type.is_kong
+        self.winning_conditions.is_robbing_the_kong = (
+            previous_turn_type == TurnType.SHOMIN_KAN
+        )
+
+    def do_tsumo(self, previous_turn_type: TurnType) -> None:
+        """
+        현재 플레이어의 Tsumo 액션을 수행한다.
+
+        이전 TurnType에 따라 패산의 왼쪽 또는 오른쪽에서 타일을 뽑음. 뽑은 타일을
+        현재 플레이어의 손패에 추가하고, Winning Condition을 설정한 후 가능한 action
+        list들을 확인하고 플레이어에게 전송
+
+        Args:
+            previous_turn_type (TurnType): 이전 턴의 타입
+        """
+        drawn_tiles: list[GameTile] | None
+        if previous_turn_type.is_next_replacement:
+            drawn_tiles = self.tile_deck.draw_tiles_right(1)
+        else:
+            drawn_tiles = self.tile_deck.draw_tiles(1)
+        if drawn_tiles is None:
+            self.end_round_as_draw()
+            return
+        self.hand_list[self.current_player_seat].apply_tsumo(
+            tile=drawn_tiles[0],
+        )
+        self.set_winning_conditions(
+            winning_tile=drawn_tiles[0],
+            previous_turn_type=previous_turn_type,
+        )
+        actions_lists: list[list[Action]] = self.check_actions_after_tsumo()
+        self.send_tsumo_actions_and_wait(actions_lists=actions_lists)
 
 
 class GameManager:
@@ -41,36 +276,56 @@ class GameManager:
     MAX_PLAYERS: Final[int] = 4
 
     def __init__(self) -> None:
+        """
+        GameManager 인스턴스 초기화
+        """
         self.player_list: list[Player]
         self.round_manager: RoundManager
         self.current_round: Round
         self.action_id: int
 
     def init_game(self, player_datas: list[PlayerDataReceived]) -> None:
+        """
+        주어진 플레이어 데이터를 이용해 게임을 초기화
+
+        Args:
+            player_datas (list[PlayerDataReceived]): Core Server에서 받은
+                플레이어 데이터 리스트
+        """
         if len(player_datas) != GameManager.MAX_PLAYERS:
             raise ValueError(
                 f"[GameManager] {GameManager.MAX_PLAYERS} players needed, "
                 f"{len(player_datas)} players received",
             )
         self.player_list = []
-        index_mapping: list[int] = list(range(GameManager.MAX_PLAYERS))
-        shuffle(index_mapping)
-        for i, player_data in enumerate(player_datas):
+        shuffle(player_datas)
+        for index, player_data in enumerate(player_datas):
             self.player_list.append(
                 Player.create_from_received_data(
                     player_data=player_data,
-                    index=index_mapping[i],
+                    index=index,
                 ),
             )
-
         self.round_manager = RoundManager(self)
         self.round_manager.init_round()
         self.current_round = Round.E1
         self.action_id = 0
 
+    def increase_action_id(self) -> None:
+        """
+        action_id를 1 증가
+        """
+        self.action_id += 1
+
 
 class ActionManager:
     def __init__(self, action_list: list[Action]):
+        """
+        ActionManager 인스턴스 초기화
+
+        Args:
+            action_list (list[Action]): 전체 Action 리스트
+        """
         self.action_heap: list[Action] = action_list
         heapq.heapify(self.action_heap)
         self.selected_action_heap: list[Action] = []
@@ -78,9 +333,24 @@ class ActionManager:
         self.final_action: Action | None = None
 
     def empty(self) -> bool:
+        """
+        Action heap이 비었는지 여부를 반환
+
+        Returns:
+            bool: Action heap이 비었으면 True, 아니면 False
+        """
         return not self.action_heap
 
     def push_action(self, action: Action) -> Action | None:
+        """
+        새로운 Action을 push하고, 최종 선택된 우선순위 높은 valid Action을 반환
+
+        Args:
+            action (Action): 추가할 Action
+
+        Returns:
+            Action | None: 최종 Action (없으면 None)
+        """
         if self.final_action:
             return self.final_action
         heapq.heappush(self.selected_action_heap, action)

--- a/app/services/game_manager/models/types.py
+++ b/app/services/game_manager/models/types.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from enum import IntEnum
+
+
+class TurnType(IntEnum):
+    TSUMO = 0
+    DISCARD = 1
+    SHOMIN_KAN = 2
+    DAIMIN_KAN = 3
+    AN_KAN = 4
+    CHII = 5
+    PON = 6
+    FLOWER = 7
+
+    @property
+    def next_turn(self) -> TurnType:
+        return (
+            TurnType.DISCARD
+            if self in {TurnType.TSUMO, TurnType.CHII, TurnType.PON}
+            else TurnType.TSUMO
+        )
+
+    @property
+    def is_next_replacement(self) -> bool:
+        return self in {
+            TurnType.SHOMIN_KAN,
+            TurnType.DAIMIN_KAN,
+            TurnType.AN_KAN,
+            TurnType.FLOWER,
+        }
+
+    @property
+    def is_next_discard(self) -> bool:
+        return self in {TurnType.TSUMO, TurnType.PON, TurnType.CHII}
+
+    @property
+    def is_kong(self) -> bool:
+        return self in {TurnType.SHOMIN_KAN, TurnType.DAIMIN_KAN, TurnType.AN_KAN}
+
+
+class ActionType(IntEnum):
+    SKIP = 0
+    HU = 1
+    KAN = 2
+    PON = 3
+    CHII = 4
+    FLOWER = 5
+
+
+class CallBlockType(IntEnum):
+    CHII = 0
+    PUNG = 1
+    AN_KONG = 2
+    SHOMIN_KONG = 3
+    DAIMIN_KONG = 4

--- a/tests/test_action_manager.py
+++ b/tests/test_action_manager.py
@@ -1,8 +1,9 @@
 import pytest
 
 from app.services.game_manager.models.action import Action
-from app.services.game_manager.models.enums import ActionType, RelativeSeat
+from app.services.game_manager.models.enums import RelativeSeat
 from app.services.game_manager.models.manager import ActionManager
+from app.services.game_manager.models.types import ActionType
 
 
 @pytest.mark.parametrize(

--- a/tests/test_game_hand.py
+++ b/tests/test_game_hand.py
@@ -4,8 +4,9 @@ from copy import deepcopy
 import pytest
 
 from app.services.game_manager.models.call_block import CallBlock
-from app.services.game_manager.models.enums import CallBlockType, GameTile
+from app.services.game_manager.models.enums import GameTile
 from app.services.game_manager.models.hand import GameHand
+from app.services.game_manager.models.types import CallBlockType
 
 
 @pytest.mark.parametrize(

--- a/tests/test_round_manager.py
+++ b/tests/test_round_manager.py
@@ -1,0 +1,85 @@
+from collections import Counter
+from unittest.mock import Mock
+
+import pytest
+
+from app.services.game_manager.models.deck import Deck
+from app.services.game_manager.models.enums import AbsoluteSeat
+from app.services.game_manager.models.hand import GameHand
+from app.services.game_manager.models.manager import GameManager, RoundManager
+from app.services.game_manager.models.types import TurnType
+from app.services.game_manager.models.winning_conditions import GameWinningConditions
+
+
+def test_init_round():
+    gm = GameManager()
+    rm = RoundManager(gm)
+    rm.tile_deck = Deck()
+    rm.hand_list = [
+        GameHand.create_from_tiles(tiles=list(range(13)))
+        for _ in range(GameManager.MAX_PLAYERS)
+    ]
+    rm.kawa_list = [[] for _ in range(GameManager.MAX_PLAYERS)]
+    rm.visible_tiles_count = Counter()
+    rm.winning_conditions = GameWinningConditions.create_default_conditions()
+    rm.current_player_seat = AbsoluteSeat.EAST
+    rm.init_round()
+    assert isinstance(rm.hand_list, list)
+    assert len(rm.hand_list) == GameManager.MAX_PLAYERS
+    assert isinstance(rm.kawa_list, list)
+    assert isinstance(rm.visible_tiles_count, Counter)
+    assert hasattr(rm.winning_conditions, "winning_tile")
+    assert rm.current_player_seat is not None
+
+
+@pytest.mark.parametrize(
+    "previous_action, expected_seat",
+    [
+        (None, AbsoluteSeat((AbsoluteSeat.EAST + 1) % 4)),
+        (Mock(seat_priority=2), AbsoluteSeat((AbsoluteSeat.EAST + 2) % 4)),
+    ],
+)
+def test_move_current_player_seat_to_next(previous_action, expected_seat):
+    gm = GameManager()
+    rm = RoundManager(gm)
+    rm.current_player_seat = AbsoluteSeat.EAST
+    rm.move_current_player_seat_to_next(previous_action)
+    assert rm.current_player_seat == expected_seat
+
+
+@pytest.mark.parametrize(
+    "previous_turn, previous_action, expected_method",
+    [
+        (TurnType.DISCARD, None, "do_discard"),
+        (TurnType.TSUMO, Mock(seat_priority=1), "do_tsumo"),
+    ],
+)
+def test_proceed_next_turn(
+    monkeypatch,
+    previous_turn,
+    previous_action,
+    expected_method,
+):
+    gm = GameManager()
+    rm = RoundManager(gm)
+    rm.current_player_seat = AbsoluteSeat.EAST
+    called = {}
+
+    def fake_do_tsumo(previous_turn_type, **kwargs):
+        called["method"] = "do_tsumo"
+        previous_turn_type, kwargs
+
+    def fake_do_discard(previous_turn_type, **kwargs):
+        called["method"] = "do_discard"
+        previous_turn_type, kwargs
+
+    monkeypatch.setattr(rm, "do_tsumo", fake_do_tsumo)
+    monkeypatch.setattr(rm, "do_discard", fake_do_discard)
+    mock_turn = Mock()
+    mock_turn.next_turn = previous_turn
+    mock_turn.is_next_replacement = False
+    mock_turn.is_next_discard = previous_turn == TurnType.DISCARD
+    mock_turn.is_kong = False
+    rm.proceed_next_turn(mock_turn, previous_action)
+    assert "method" in called
+    assert called["method"] == expected_method


### PR DESCRIPTION
[![GAME-20](https://badgen.net/badge/JIRA/GAME-20/0052CC)](https://mcrs.atlassian.net/browse/GAME-20) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

# RoundManager에 Tsumo 기능 추가 및 순환 참조 방지를 위한 리팩토링

## 개요
- `Tsumo` 기능을 `RoundManager`에 추가했습니다.
- `enums.py` 등 일부 모듈에서 순환 참조 문제가 발생하지 않도록, `TYPE_CHECKING`을 사용하도록 하였고 파일을 `enums.py`와 `types.py`로 분리하는 방식으로 리팩토링했습니다.

## 주요 변경 사항
- **RoundManager**:
  - `do_tsumo(previous_turn_type: TurnType)` 메서드를 구현하여,  
    이전 턴에 따라 타일을 패산의 왼쪽이나 오른쪽에서 뽑고(`draw_tiles`), 손패에 적용한 뒤  
    `Winning Condition`을 설정하도록 했습니다.
  - `proceed_next_turn` 함수에서, 이전 Turn이나 Action에 따라 Tsumo가 필요한 상황에서 `do_tsumo`를 호출하고, Discard가 필요한 상황에서 `do_discard`를 호출하도록 했습니다.
- **enums.py**:
  - `Action`을 바로 import하지 않고, `TYPE_CHECKING`을 사용해  
    순환 참조를 방지했습니다.
  - `types.py`로 타입에 대한 enum은 분리했습니다.
- **docstring과 주석을 한글로 넣었습니다.**

## 테스트
- `test_round_manager.py`에 `RoundManager`에 관한 테스트를 추가했습니다.

## 추가 참고 사항
-  향후 배패에서 화패 빼는 절차나 `Discard` 로직 등에 대한 RoundManager 내 추가 구현이 필요합니다. 틀만 만들어서 **TODO:** 로 표시해놓았습니다.

[GAME-20]: https://mcrs.atlassian.net/browse/GAME-20?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ