### PR TITLE
 GAME-41 add network manager class

### DIFF
--- a/app/core/network_service.py
+++ b/app/core/network_service.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from app.core.room_manager import RoomManager
+
+
+class NetworkService:
+    def __init__(self, room_manager: RoomManager) -> None:
+        self.room_manager = room_manager
+
+    async def send_personal_message(
+        self,
+        message: dict[str, Any],
+        game_id: int,
+        user_id: str,
+    ) -> None:
+        await self.room_manager.send_personal_message(message, game_id, user_id)
+
+    async def broadcast(
+        self,
+        message: dict[str, Any],
+        game_id: int,
+        exclude_user_id: str | None = None,
+    ) -> None:
+        await self.room_manager.broadcast(message, game_id, exclude_user_id)

--- a/app/dependencies/network_service.py
+++ b/app/dependencies/network_service.py
@@ -1,0 +1,15 @@
+from typing import TYPE_CHECKING
+
+from fastapi import Depends
+
+from app.core.network_service import NetworkService
+from app.dependencies.room_manager import get_room_manager
+
+if TYPE_CHECKING:
+    from app.core.room_manager import RoomManager
+
+
+def get_network_service(
+    room_manager: "RoomManager" = Depends(get_room_manager),
+) -> NetworkService:
+    return NetworkService(room_manager)

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -9,7 +9,9 @@ from typing import Any, Final, TypeVar
 
 from fastapi import Depends
 
+from app.core.network_service import NetworkService
 from app.core.room_manager import RoomManager
+from app.dependencies.network_service import get_network_service
 from app.dependencies.room_manager import get_room_manager
 from app.schemas.ws import MessageEventType
 from app.services.game_manager.models.action import Action
@@ -471,7 +473,7 @@ class RoundManager:
                 "actions": actions_lists[self.current_player_seat],
                 "action_id": self.game_manager.action_id,
             }
-            await self.game_manager.room_manager.send_personal_message(
+            await self.game_manager.network_service.send_personal_message(
                 message=message,
                 game_id=self.game_manager.game_id,
                 user_id=self.game_manager.player_list[
@@ -518,7 +520,7 @@ class RoundManager:
             case GameEventType.HU:
                 pass
             case GameEventType.FLOWER:
-                await self.game_manager.room_manager.broadcast(
+                await self.game_manager.network_service.broadcast(
                     message={
                         "event": MessageEventType.FLOWER,
                         "player_seat": response_action.player_seat,
@@ -527,7 +529,7 @@ class RoundManager:
                     game_id=self.game_manager.game_id,
                 )
             case GameEventType.AN_KAN:
-                await self.game_manager.room_manager.send_personal_message(
+                await self.game_manager.network_service.send_personal_message(
                     message={
                         "event": MessageEventType.AN_KAN,
                         "player_seat": response_action.player_seat,
@@ -538,7 +540,7 @@ class RoundManager:
                         self.seat_to_player_index[response_action.player_seat]
                     ].uid,
                 )
-                await self.game_manager.room_manager.broadcast(
+                await self.game_manager.network_service.broadcast(
                     message={
                         "event": MessageEventType.AN_KAN,
                         "player_seat": response_action.player_seat,
@@ -554,7 +556,7 @@ class RoundManager:
                 self.hands[self.current_player_seat].apply_discard(
                     tile=response_action.data["tile"],
                 )
-                await self.game_manager.room_manager.broadcast(
+                await self.game_manager.network_service.broadcast(
                     message={
                         "event": MessageEventType.DISCARD,
                         "tile": response_action.data["tile"],
@@ -635,9 +637,11 @@ class GameManager:
         self,
         game_id: int,
         room_manager: RoomManager = Depends(get_room_manager()),
+        network_service: NetworkService = Depends(get_network_service()),
     ) -> None:
         self.game_id: int = game_id
         self.room_manager: RoomManager = room_manager
+        self.network_service: NetworkService = network_service
         self.player_list: list[Player]
         self.player_uid_to_index: dict[str, int]
         self.round_manager: RoundManager

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -339,6 +339,8 @@ class RoundManager:
         _hand: Hand = Hand.create_from_game_hand(hand=self.hands[player_seat])
         if self.winning_conditions.winning_tile is None:
             raise ValueError("[RoundManager.get_possible_hu_choices]tile is none")
+        if self.winning_conditions.winning_tile.is_flower:
+            return []
         if self.winning_conditions.is_discarded:
             _hand.tiles[self.winning_conditions.winning_tile] += 1
         return (


### PR DESCRIPTION
[![GAME-41](https://badgen.net/badge/JIRA/GAME-41/0052CC)](https://mcrs.atlassian.net/browse/GAME-41) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Network Manager Class를 만들어서 네트워크 영역의 의존성을 분리하였습니다
지금은 클라쪽 엔드포인트와 연결하는 부분밖에 없긴한데 코어서버측과 연결도 추가할 걸 생각하면 레이어를 나누는게 좋아보여서 이렇게 했습니다

[GAME-41]: https://mcrs.atlassian.net/browse/GAME-41?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ