### PR TITLE
GAME-48 add hu and draw state, fixed init

### DIFF
--- a/app/schemas/ws.py
+++ b/app/schemas/ws.py
@@ -14,12 +14,19 @@ class GameWebSocketActionType(str, Enum):
 
 
 class MessageEventType(str, Enum):
+    HAIPAI_HAND = "haipai_hand"
     TSUMO_ACTIONS = "tsumo_actions"
     DISCARD_ACTIONS = "discard_actions"
     DISCARD = "discard"
     TSUMO = "tsumo"
+    CHII = "chii"
+    PON = "pon"
+    DAIMIN_KAN = "daimin_kan"
+    SHOMIN_KAN = "shomin_kan"
     AN_KAN = "an_kan"
     FLOWER = "flower"
+    OPEN_AN_KAN = "open_an_kan"
+    HU_HAND = "hu_hand"
 
 
 class WebSocketResponse(BaseModel):

--- a/app/services/game_manager/models/enums.py
+++ b/app/services/game_manager/models/enums.py
@@ -30,6 +30,24 @@ class Round(IntEnum):
 
     END = 16
 
+    @property
+    def number(self) -> int:
+        if self == Round.END:
+            raise ValueError("game finished")
+        return int(self.name[1])
+
+    @property
+    def wind(self) -> str:
+        if self == Round.END:
+            raise ValueError("game finished")
+        return self.name[0]
+
+    @property
+    def next_round(self) -> Round:
+        if self == Round.END:
+            raise ValueError("game finished")
+        return Round(self.value + 1)
+
 
 class AbsoluteSeat(IntEnum):
     EAST = 0

--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -33,6 +33,7 @@ from app.services.game_manager.models.player import (
 from app.services.game_manager.models.round_fsm import (
     DiscardState,
     DrawState,
+    HuState,
     InitState,
     RobbingKongState,
     RoundState,
@@ -102,24 +103,61 @@ class RoundManager:
         self.tile_deck = Deck()
         self.hands = [
             GameHand.create_from_tiles(tiles=self.tile_deck.draw_haipai())
-            for _ in range(GameManager.MAX_PLAYERS)
+            for _ in range(self.game_manager.MAX_PLAYERS)
         ]
-        self.kawas = [[] for _ in range(GameManager.MAX_PLAYERS)]
+        self.kawas = [[] for _ in range(self.game_manager.MAX_PLAYERS)]
         self.visible_tiles_count = Counter()
         self.winning_conditions = GameWinningConditions.create_default_conditions()
+        self.init_seat_index_mapping()
         self.action_manager = None
         self.current_player_seat = AbsoluteSeat.EAST
 
+    def init_seat_index_mapping(self) -> None:
+        shift = self.game_manager.current_round.number - 1
+        wind = self.game_manager.current_round.wind
+        base_mapping = {
+            "E": {
+                AbsoluteSeat.EAST: 0,
+                AbsoluteSeat.SOUTH: 1,
+                AbsoluteSeat.WEST: 2,
+                AbsoluteSeat.NORTH: 3,
+            },
+            "S": {
+                AbsoluteSeat.EAST: 1,
+                AbsoluteSeat.SOUTH: 0,
+                AbsoluteSeat.WEST: 3,
+                AbsoluteSeat.NORTH: 2,
+            },
+            "W": {
+                AbsoluteSeat.EAST: 2,
+                AbsoluteSeat.SOUTH: 3,
+                AbsoluteSeat.WEST: 1,
+                AbsoluteSeat.NORTH: 0,
+            },
+            "N": {
+                AbsoluteSeat.EAST: 3,
+                AbsoluteSeat.SOUTH: 2,
+                AbsoluteSeat.WEST: 0,
+                AbsoluteSeat.NORTH: 1,
+            },
+        }[wind]
+        self.seat_to_player_index = {
+            seat: (base + shift) % 4 for seat, base in base_mapping.items()
+        }
+        self.player_index_to_seat = {v: k for k, v in self.seat_to_player_index.items()}
+
     async def send_init_events(self) -> None:
         for seat in AbsoluteSeat:
-            init_data = {"hand": self.hands[seat].tiles.elements()}
-            init_event = GameEvent(
-                event_type=GameEventType.INIT_HAIPAI,
-                player_seat=seat,
-                data=init_data,
-                action_id=self.game_manager.action_id,
+            player: Player = self.get_player_from_seat(seat=seat)
+            await self.game_manager.network_service.send_personal_message(
+                message={
+                    "event": MessageEventType.HU_HAND,
+                    "player_seat": seat,
+                    "data": {"hand": self.hands[seat].tiles.elements()},
+                },
+                game_id=self.game_manager.game_id,
+                user_id=player.uid,
             )
-            await self.game_manager.event_queue.put(init_event)
 
     async def do_init_flower_action(self) -> None:
         for seat in AbsoluteSeat:
@@ -147,6 +185,8 @@ class RoundManager:
     ) -> RoundState:
         tile: GameTile | None
         match next_event.event_type:
+            case GameEventType.HU:
+                return HuState(current_event=next_event)
             case GameEventType.TSUMO:
                 if self.tile_deck.tiles_remaining == 0:
                     return DrawState()
@@ -178,7 +218,7 @@ class RoundManager:
         return await self.send_actions_and_wait(actions_lists=actions_lists)
 
     def check_actions_after_shomin_kong(self) -> list[list[Action]]:
-        result: list[list[Action]] = [[] for _ in range(GameManager.MAX_PLAYERS)]
+        result: list[list[Action]] = [[] for _ in range(self.game_manager.MAX_PLAYERS)]
         for player_seat in AbsoluteSeat:
             if player_seat == self.current_player_seat:
                 continue
@@ -204,7 +244,7 @@ class RoundManager:
         return await self.send_actions_and_wait(actions_lists=actions_lists)
 
     def check_actions_after_discard(self) -> list[list[Action]]:
-        result: list[list[Action]] = [[] for _ in range(GameManager.MAX_PLAYERS)]
+        result: list[list[Action]] = [[] for _ in range(self.game_manager.MAX_PLAYERS)]
         for player_seat in AbsoluteSeat:
             if player_seat == self.current_player_seat:
                 continue
@@ -254,10 +294,11 @@ class RoundManager:
                 final_action,
                 selected_events,
             )
-            if response_event is not None:
-                await self.send_response_action_event(response_action=response_event)
             return response_event
         return None
+
+    def get_player_from_seat(self, seat: AbsoluteSeat) -> Player:
+        return self.game_manager.player_list[self.seat_to_player_index[seat]]
 
     async def _send_discard_message(
         self,
@@ -269,7 +310,7 @@ class RoundManager:
             "actions": actions,
             "action_id": self.game_manager.action_id,
         }
-        player: Player = self.game_manager.player_list[self.seat_to_player_index[seat]]
+        player: Player = self.get_player_from_seat(seat)
         await self.game_manager.network_service.send_personal_message(
             message=message,
             game_id=self.game_manager.game_id,
@@ -345,17 +386,42 @@ class RoundManager:
                 return event
         return None
 
-    def end_round_as_draw(self) -> None:
-        """
-        Round를 유국으로 종료
+    async def end_round_as_hu(self, current_event: GameEvent) -> None:
+        await self.send_hu_hand_info(hu_player_seat=current_event.player_seat)
+        await self.send_an_kan_info()
 
-        이 메서드는 추후 구현되어야 함
-        """
-        # TODO: 유국 처리 로직 구현
-        pass
+    async def send_hu_hand_info(self, hu_player_seat: AbsoluteSeat) -> None:
+        await self.game_manager.network_service.broadcast(
+            message={
+                "event": MessageEventType.HU_HAND,
+                "player_seat": hu_player_seat,
+                "data": {"hand": self.hands[hu_player_seat].tiles.elements()},
+            },
+            game_id=self.game_manager.game_id,
+        )
+
+    async def end_round_as_draw(self) -> None:
+        await self.send_an_kan_info()
+
+    async def send_an_kan_info(self) -> None:
+        an_kan_infos = [
+            [
+                block.first_tile
+                for block in hand.call_blocks
+                if block.type == CallBlockType.AN_KONG
+            ]
+            for hand in self.hands
+        ]
+        await self.game_manager.network_service.broadcast(
+            message={
+                "event": MessageEventType.FLOWER,
+                "data": {"an_kan_infos": an_kan_infos},
+            },
+            game_id=self.game_manager.game_id,
+        )
 
     def check_actions_after_tsumo(self) -> list[list[Action]]:
-        result: list[list[Action]] = [[] for _ in range(GameManager.MAX_PLAYERS)]
+        result: list[list[Action]] = [[] for _ in range(self.game_manager.MAX_PLAYERS)]
         result[self.current_player_seat].extend(
             self.get_possible_hu_choices(player_seat=self.current_player_seat),
         )
@@ -394,7 +460,7 @@ class RoundManager:
                     round_wind=AbsoluteSeat(self.game_manager.current_round // 4),
                 ),
             ).result.total_score
-            >= GameManager.MINIMUM_HU_SCORE
+            >= self.game_manager.MINIMUM_HU_SCORE
             else []
         )
 
@@ -494,7 +560,7 @@ class RoundManager:
         elapsed = loop.time() - start
         return result, elapsed
 
-    async def send_tsumo_actions_and_wait_api(
+    async def send_tsumo_actions_and_wait(
         self,
         actions_lists: list[list[Action]],
     ) -> GameEvent:
@@ -505,13 +571,13 @@ class RoundManager:
                 "actions": actions_lists[self.current_player_seat],
                 "action_id": self.game_manager.action_id,
             }
+            player: Player = self.get_player_from_seat(self.current_player_seat)
             await self.game_manager.network_service.send_personal_message(
                 message=message,
                 game_id=self.game_manager.game_id,
-                user_id=self.game_manager.player_list[
-                    self.seat_to_player_index[self.current_player_seat]
-                ].uid,
+                user_id=player.uid,
             )
+        self.game_manager.increase_action_id()
 
         response_event: GameEvent | None
         elapsed_time: float
@@ -568,8 +634,8 @@ class RoundManager:
         return response_event
 
     async def do_action(self, current_event: GameEvent) -> RoundState:
-        await self.send_response_action_event(
-            response_action=current_event,
+        await self.send_response_event(
+            response_event=current_event,
         )
         self.apply_response_event(response_event=current_event)
         match current_event.event_type:
@@ -592,7 +658,6 @@ class RoundManager:
             case _:
                 raise ValueError("invalid action")
 
-    # TODO 각종 GameEventType에 대응하는 apply 추가
     def apply_response_event(
         self,
         response_event: GameEvent,
@@ -637,16 +702,16 @@ class RoundManager:
             case CallBlockType.SHOMIN_KONG:
                 self.visible_tiles_count[call_block.first_tile] += 1
 
-    async def send_response_action_event(
+    async def send_response_event(
         self,
-        response_action: GameEvent,
+        response_event: GameEvent,
     ) -> None:
-        match response_action.event_type:
+        match response_event.event_type:
             case GameEventType.FLOWER:
                 await self.game_manager.network_service.broadcast(
                     message={
                         "event": MessageEventType.FLOWER,
-                        "player_seat": response_action.player_seat,
+                        "player_seat": response_event.player_seat,
                         "tile": None,
                     },
                     game_id=self.game_manager.game_id,
@@ -655,33 +720,66 @@ class RoundManager:
                 await self.game_manager.network_service.send_personal_message(
                     message={
                         "event": MessageEventType.AN_KAN,
-                        "player_seat": response_action.player_seat,
-                        "tile": response_action.data["tile"],
+                        "player_seat": response_event.player_seat,
+                        "tile": response_event.data["tile"],
                     },
                     game_id=self.game_manager.game_id,
                     user_id=self.game_manager.player_list[
-                        self.seat_to_player_index[response_action.player_seat]
+                        self.seat_to_player_index[response_event.player_seat]
                     ].uid,
                 )
                 await self.game_manager.network_service.broadcast(
                     message={
                         "event": MessageEventType.AN_KAN,
-                        "player_seat": response_action.player_seat,
+                        "player_seat": response_event.player_seat,
                         "tile": None,
                     },
                     game_id=self.game_manager.game_id,
                     exclude_user_id=self.game_manager.player_list[
-                        self.seat_to_player_index[response_action.player_seat]
+                        self.seat_to_player_index[response_event.player_seat]
                     ].uid,
                 )
-            case GameEventType.DISCARD:
-                self.hands[self.current_player_seat].apply_discard(
-                    tile=response_action.data["tile"],
+            case GameEventType.CHII:
+                await self.game_manager.network_service.broadcast(
+                    message={
+                        "event": MessageEventType.CHII,
+                        "player_seat": response_event.player_seat,
+                        "tile": response_event.data["tile"],
+                    },
+                    game_id=self.game_manager.game_id,
                 )
+            case GameEventType.PON:
+                await self.game_manager.network_service.broadcast(
+                    message={
+                        "event": MessageEventType.PON,
+                        "player_seat": response_event.player_seat,
+                        "tile": response_event.data["tile"],
+                    },
+                    game_id=self.game_manager.game_id,
+                )
+            case GameEventType.DAIMIN_KAN:
+                await self.game_manager.network_service.broadcast(
+                    message={
+                        "event": MessageEventType.DAIMIN_KAN,
+                        "player_seat": response_event.player_seat,
+                        "tile": response_event.data["tile"],
+                    },
+                    game_id=self.game_manager.game_id,
+                )
+            case GameEventType.SHOMIN_KAN:
+                await self.game_manager.network_service.broadcast(
+                    message={
+                        "event": MessageEventType.SHOMIN_KAN,
+                        "player_seat": response_event.player_seat,
+                        "tile": response_event.data["tile"],
+                    },
+                    game_id=self.game_manager.game_id,
+                )
+            case GameEventType.DISCARD:
                 await self.game_manager.network_service.broadcast(
                     message={
                         "event": MessageEventType.DISCARD,
-                        "tile": response_action.data["tile"],
+                        "tile": response_event.data["tile"],
                     },
                     game_id=self.game_manager.game_id,
                 )
@@ -725,7 +823,7 @@ class RoundManager:
             previous_event_type=previous_event_type,
         )
         actions_lists: list[list[Action]] = self.check_actions_after_tsumo()
-        return await self.send_tsumo_actions_and_wait_api(
+        return await self.send_tsumo_actions_and_wait(
             actions_lists=actions_lists,
         )
 
@@ -751,16 +849,16 @@ class GameManager:
         self.action_id: int
         self.event_queue: asyncio.Queue[GameEvent]
 
-    def init_game(self, player_datas: list[PlayerData]) -> None:
-        if len(player_datas) != GameManager.MAX_PLAYERS:
+    def init_game(self, players_data: list[PlayerData]) -> None:
+        if len(players_data) != self.MAX_PLAYERS:
             raise ValueError(
-                f"[GameManager] {GameManager.MAX_PLAYERS} players needed, "
-                f"{len(player_datas)} players received",
+                f"[GameManager] {self.MAX_PLAYERS} players needed, "
+                f"{len(players_data)} players received",
             )
         self.player_list = []
         self.player_uid_to_index = {}
-        shuffle(player_datas)
-        for index, player_data in enumerate(player_datas):
+        shuffle(players_data)
+        for index, player_data in enumerate(players_data):
             self.player_list.append(
                 Player.create_from_received_data(
                     player_data=player_data,
@@ -776,33 +874,12 @@ class GameManager:
     async def start_game(self) -> None:
         for _ in range(self.TOTAL_ROUNDS):
             await self.round_manager.run_round()
+            self.current_round = self.current_round.next_round
         await self.submit_game_result()
 
     # TODO submit game result to core sever
     async def submit_game_result(self) -> None:
         pass
-
-    def get_valid_discard_result(
-        self,
-        uid: str,
-        tile: GameTile,
-    ) -> dict[str, AbsoluteSeat]:
-        player_seat: AbsoluteSeat = self.round_manager.player_index_to_seat[
-            self.player_uid_to_index[uid]
-        ]
-        return (
-            {"seat": player_seat}
-            if tile in self.round_manager.hands[player_seat].tiles
-            else {}
-        )
-
-    async def enqueue_event(self, event: GameEvent) -> None:
-        try:
-            await self.event_queue.put(event)
-        except asyncio.CancelledError:
-            raise
-        except Exception as e:
-            print(f"Failed to enqueue event: {e}")
 
     def increase_action_id(self) -> None:
         self.action_id += 1
@@ -810,12 +887,6 @@ class GameManager:
 
 class ActionManager:
     def __init__(self, action_list: list[Action]):
-        """
-        ActionManager 인스턴스 초기화
-
-        Args:
-            action_list (list[Action]): 전체 Action 리스트
-        """
         self.action_heap: list[Action] = action_list
         heapq.heapify(self.action_heap)
         self.selected_action_heap: list[Action] = []
@@ -823,12 +894,6 @@ class ActionManager:
         self.final_action: Action | None = None
 
     def empty(self) -> bool:
-        """
-        Action heap이 비었는지 여부를 반환
-
-        Returns:
-            bool: Action heap이 비었으면 True, 아니면 False
-        """
         return not self.action_heap
 
     def push_action(self, action: Action) -> Action | None:

--- a/app/services/game_manager/models/round_fsm.py
+++ b/app/services/game_manager/models/round_fsm.py
@@ -55,7 +55,6 @@ class ActionState(RoundState):
         return next_state
 
 
-# TODO
 class DiscardState(RoundState):
     def __init__(self, prev_type: GameEventType, tile: GameTile):
         self.prev_type = prev_type
@@ -90,17 +89,16 @@ class RobbingKongState(RoundState):
         )
 
 
-# TODO
 class DrawState(RoundState):
     async def run(self, manager: RoundManager) -> RoundState | None:
-        # TODO
-        manager.end_round_as_draw()
+        await manager.end_round_as_draw()
         return None
 
 
-# TODO
 class HuState(RoundState):
+    def __init__(self, current_event: GameEvent):
+        self.current_event = current_event
+
     async def run(self, manager: RoundManager) -> RoundState | None:
-        # TODO
-        manager
+        await manager.end_round_as_hu(current_event=self.current_event)
         return None

--- a/tests/test_game_manager.py
+++ b/tests/test_game_manager.py
@@ -1,10 +1,8 @@
 import asyncio
-from collections import Counter
 
 import pytest
 
-from app.services.game_manager.models.enums import AbsoluteSeat, GameTile, Round
-from app.services.game_manager.models.event import GameEvent
+from app.services.game_manager.models.enums import AbsoluteSeat, Round
 from app.services.game_manager.models.manager import GameManager
 
 
@@ -85,33 +83,6 @@ def test_increase_action_id(game_manager):
     current = gm.action_id
     gm.increase_action_id()
     assert gm.action_id == current + 1
-
-
-def test_get_valid_discard_result(game_manager):
-    gm = game_manager
-    index = gm.player_uid_to_index["user0"]
-    seat = gm.round_manager.player_index_to_seat[index]
-
-    class DummyHand:
-        def __init__(self):
-            self.tiles = Counter()
-
-    dummy_hand = DummyHand()
-    dummy_hand.tiles[GameTile.M1] = 1
-    gm.round_manager.hands = {seat: dummy_hand}
-    result = gm.get_valid_discard_result("user0", GameTile.M1)
-    assert "seat" in result
-    result_empty = gm.get_valid_discard_result("user0", GameTile.M9)
-    assert result_empty == {}
-
-
-@pytest.mark.asyncio
-async def test_enqueue_event(game_manager):
-    gm = game_manager
-    event = GameEvent(event_type="TEST", player_seat=0, data={}, action_id=0)
-    await gm.enqueue_event(event)
-    queued_event = await gm.event_queue.get()
-    assert queued_event == event
 
 
 @pytest.mark.asyncio

--- a/tests/test_round_fsm.py
+++ b/tests/test_round_fsm.py
@@ -1,91 +1,85 @@
 import pytest
 
-from app.services.game_manager.models.enums import GameTile
+from app.services.game_manager.models.enums import AbsoluteSeat, GameTile
 from app.services.game_manager.models.event import GameEvent
 from app.services.game_manager.models.round_fsm import (
     ActionState,
     DiscardState,
-    DrawState,
     FlowerState,
     HuState,
     InitState,
     RobbingKongState,
-    RoundState,
     TsumoState,
 )
 from app.services.game_manager.models.types import GameEventType
 
 
-class DummyState(RoundState):
-    async def run(self, manager) -> RoundState | None:
-        return None
-
-
-class FakeRoundManager:
+class DummyRoundManager:
     def __init__(self):
         self.init_called = False
         self.send_init_events_called = False
-        self.do_init_flower_action_called = False
+        self.do_init_flower_called = False
         self.do_tsumo_called = False
-        self.get_next_state_called = False
         self.do_action_called = False
         self.do_discard_called = False
         self.do_robbing_kong_called = False
-        self.end_round_as_draw_called = False
+        self.end_round_as_hu_called = False
 
-    def init_round_data(self):
+    def init_round_data(self) -> None:
         self.init_called = True
 
-    async def send_init_events(self):
+    async def send_init_events(self) -> None:
         self.send_init_events_called = True
 
-    async def do_init_flower_action(self):
-        self.do_init_flower_action_called = True
+    async def do_init_flower_action(self) -> None:
+        self.do_init_flower_called = True
 
-    async def do_tsumo(self, previous_event_type):
+    async def do_tsumo(self, previous_event_type: GameEventType) -> GameEvent:
         self.do_tsumo_called = True
         return GameEvent(
             event_type=GameEventType.TSUMO,
-            player_seat=0,
-            data={},
+            player_seat=AbsoluteSeat.EAST,
+            data={"tile": GameTile.M1},
             action_id=1,
         )
 
-    def get_next_state(self, previous_event_type, next_event):
-        self.get_next_state_called = True
-        if next_event.event_type == GameEventType.TSUMO:
-            return DummyState()
+    async def do_action(self, current_event: GameEvent) -> object:
+        self.do_action_called = True
+        return DiscardState(prev_type=GameEventType.DISCARD, tile=GameTile.M1)
+
+    async def do_discard(
+        self,
+        previous_turn_type: GameEventType,
+        discarded_tile: GameTile,
+    ) -> GameEvent | None:
+        self.do_discard_called = True
         return None
 
-    async def do_action(self, current_event):
-        self.do_action_called = True
-        return DummyState()
-
-    async def do_discard(self, previous_turn_type, discarded_tile):
-        self.do_discard_called = True
-        return GameEvent(
-            event_type=GameEventType.DISCARD,
-            player_seat=0,
-            data={"tile": discarded_tile},
-            action_id=2,
-        )
-
-    async def do_robbing_kong(self, robbing_tile):
+    async def do_robbing_kong(self, robbing_tile: GameTile) -> GameEvent | None:
         self.do_robbing_kong_called = True
-        return GameEvent(
-            event_type=GameEventType.ROBBING_KONG,
-            player_seat=0,
-            data={"tile": robbing_tile},
-            action_id=3,
-        )
+        return None
 
-    def end_round_as_draw(self):
-        self.end_round_as_draw_called = True
+    def get_next_state(
+        self,
+        previous_event_type: GameEventType,
+        next_event: GameEvent,
+    ) -> object:
+        return TsumoState(prev_type=next_event.event_type)
+
+    def increase_action_id(self) -> None:
+        pass
+
+    @property
+    def default_turn_timeout(self) -> float:
+        return 60.0
+
+    async def end_round_as_hu(self, current_event: GameEvent) -> None:
+        self.end_round_as_hu_called = True
 
 
 @pytest.mark.asyncio
 async def test_init_state():
-    manager = FakeRoundManager()
+    manager = DummyRoundManager()
     state = InitState()
     next_state = await state.run(manager)
     assert manager.init_called
@@ -97,10 +91,10 @@ async def test_init_state():
 
 @pytest.mark.asyncio
 async def test_flower_state():
-    manager = FakeRoundManager()
+    manager = DummyRoundManager()
     state = FlowerState()
     next_state = await state.run(manager)
-    assert manager.do_init_flower_action_called
+    assert manager.do_init_flower_called
     from app.services.game_manager.models.round_fsm import TsumoState
 
     assert isinstance(next_state, TsumoState)
@@ -109,63 +103,107 @@ async def test_flower_state():
 
 @pytest.mark.asyncio
 async def test_tsumo_state():
-    manager = FakeRoundManager()
+    manager = DummyRoundManager()
     state = TsumoState(prev_type=GameEventType.DISCARD)
     next_state = await state.run(manager)
     assert manager.do_tsumo_called
-    assert manager.get_next_state_called
-    assert isinstance(next_state, DummyState)
+    assert isinstance(next_state, TsumoState)
 
 
 @pytest.mark.asyncio
 async def test_action_state():
-    manager = FakeRoundManager()
+    manager = DummyRoundManager()
     dummy_event = GameEvent(
         event_type=GameEventType.DISCARD,
-        player_seat=0,
-        data={},
+        player_seat=AbsoluteSeat.EAST,
+        data={"tile": GameTile.M1},
         action_id=1,
     )
     state = ActionState(current_event=dummy_event)
     next_state = await state.run(manager)
     assert manager.do_action_called
-    assert isinstance(next_state, DummyState)
+    assert isinstance(next_state, DiscardState)
 
 
 @pytest.mark.asyncio
-async def test_discard_state():
-    manager = FakeRoundManager()
-    dummy_tile = GameTile.M1
-    state = DiscardState(prev_type=GameEventType.DISCARD, tile=dummy_tile)
+async def test_discard_state_returns_tsumo_state_when_none():
+    manager = DummyRoundManager()
+    state = DiscardState(prev_type=GameEventType.DISCARD, tile=GameTile.M1)
+    next_state = await state.run(manager)
+    from app.services.game_manager.models.round_fsm import TsumoState
+
+    assert isinstance(next_state, TsumoState)
+    assert next_state.prev_type == GameEventType.DISCARD
+
+
+@pytest.mark.asyncio
+async def test_discard_state_returns_next_state():
+    class DummyManager(DummyRoundManager):
+        async def do_discard(
+            self,
+            previous_turn_type: GameEventType,
+            discarded_tile: GameTile,
+        ) -> GameEvent | None:
+            self.do_discard_called = True
+            return GameEvent(
+                event_type=GameEventType.DISCARD,
+                player_seat=AbsoluteSeat.EAST,
+                data={"tile": discarded_tile},
+                action_id=2,
+            )
+
+    manager = DummyManager()
+    state = DiscardState(prev_type=GameEventType.DISCARD, tile=GameTile.M1)
     next_state = await state.run(manager)
     assert manager.do_discard_called
-    if next_state is not None:
-        assert isinstance(next_state, DummyState)
+    from app.services.game_manager.models.round_fsm import TsumoState
+
+    assert isinstance(next_state, TsumoState)
 
 
 @pytest.mark.asyncio
-async def test_robbing_kong_state():
-    manager = FakeRoundManager()
-    dummy_tile = GameTile.M1
-    state = RobbingKongState(tile=dummy_tile)
+async def test_robbing_kong_state_returns_tsumo_state_when_none():
+    manager = DummyRoundManager()
+    state = RobbingKongState(tile=GameTile.M1)
+    next_state = await state.run(manager)
+    from app.services.game_manager.models.round_fsm import TsumoState
+
+    assert isinstance(next_state, TsumoState)
+    assert next_state.prev_type == GameEventType.ROBBING_KONG
+
+
+@pytest.mark.asyncio
+async def test_robbing_kong_state_returns_next_state():
+    class DummyManager(DummyRoundManager):
+        async def do_robbing_kong(self, robbing_tile: GameTile) -> GameEvent | None:
+            self.do_robbing_kong_called = True
+            return GameEvent(
+                event_type=GameEventType.ROBBING_KONG,
+                player_seat=AbsoluteSeat.EAST,
+                data={"tile": robbing_tile},
+                action_id=3,
+            )
+
+    manager = DummyManager()
+    state = RobbingKongState(tile=GameTile.M1)
     next_state = await state.run(manager)
     assert manager.do_robbing_kong_called
-    if next_state is not None:
-        assert isinstance(next_state, DummyState)
+    from app.services.game_manager.models.round_fsm import TsumoState
 
-
-@pytest.mark.asyncio
-async def test_draw_state():
-    manager = FakeRoundManager()
-    state = DrawState()
-    next_state = await state.run(manager)
-    assert manager.end_round_as_draw_called
-    assert next_state is None
+    # Dummy get_next_state returns TsumoState
+    assert isinstance(next_state, TsumoState)
 
 
 @pytest.mark.asyncio
 async def test_hu_state():
-    manager = FakeRoundManager()
-    state = HuState()
+    manager = DummyRoundManager()
+    dummy_event = GameEvent(
+        event_type=GameEventType.HU,
+        player_seat=AbsoluteSeat.EAST,
+        data={"tile": GameTile.M1},
+        action_id=4,
+    )
+    state = HuState(current_event=dummy_event)
     next_state = await state.run(manager)
+    assert manager.end_round_as_hu_called
     assert next_state is None


### PR DESCRIPTION
[![GAME-48](https://badgen.net/badge/JIRA/GAME-48/0052CC)](https://mcrs.atlassian.net/browse/GAME-48) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

FSM에 화료 State(HuState)와 유국 State(DrawState)를 추가했습니다.

Init과정에서 자리 바꾸는 로직을 추가했습니다.

HuState에서 점수 변동 반영하도록 했습니다.

이제 게임 로직적으로는 어느정도 다 한거같습니다

[GAME-48]: https://mcrs.atlassian.net/browse/GAME-48?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ