### PR TITLE
GAME-60-receive-client-side-websocket-message

### DIFF
--- a/app/core/room_manager.py
+++ b/app/core/room_manager.py
@@ -65,6 +65,12 @@ class RoomManager:
                 self.game_managers[game_id].init_game(players_data=players_data)
 
                 task = asyncio.create_task(self.game_managers[game_id].start_game())
+                task.add_done_callback(
+                    lambda t: print(f"Task finished with exception: {t.exception()}")
+                    if t.exception()
+                    else None,
+                )
+
                 self.game_tasks[game_id] = task
 
     async def disconnect(self, game_id: int, user_id: str) -> None:

--- a/app/schemas/ws.py
+++ b/app/schemas/ws.py
@@ -14,6 +14,8 @@ class GameWebSocketActionType(str, Enum):
 
 
 class MessageEventType(str, Enum):
+    GAME_EVENT = "game_event"
+
     INIT_FLOWER_REPLACEMENT = "init_flower_replacement"
     GAME_START_INFO = "game_start_info"
     INIT_EVENT = "init_event"
@@ -34,6 +36,7 @@ class MessageEventType(str, Enum):
     PING = "ping"
     PONG = "pong"
     USER_JOINED = "user_joined"
+    SUCCESS = "success"
     ERROR = "error"
 
 

--- a/app/services/game_manager/models/round_fsm.py
+++ b/app/services/game_manager/models/round_fsm.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
-from app.services.game_manager.models.enums import GameTile
+from app.services.game_manager.models.enums import AbsoluteSeat, GameTile
 from app.services.game_manager.models.event import GameEvent
 from app.services.game_manager.models.types import GameEventType
 
@@ -31,7 +31,11 @@ class FlowerState(RoundState):
     async def run(self, manager: RoundManager) -> RoundState | None:
         print("[DEBUG] FlowerState: performing init flower action")
         await manager.do_init_flower_action()
-        print("[DEBUG] FlowerState: transition to TsumoState with prev_type=DISCARD")
+        print("[DEBUG] FlowerState: wait for init flower ok")
+        await manager.wait_for_init_flower_ok()
+        print(
+            "[DEBUG] FlowerState: transition to TsumoState with prev_type=INIT_FLOWER",
+        )
         return TsumoState(prev_type=GameEventType.INIT_FLOWER)
 
 
@@ -89,7 +93,12 @@ class DiscardState(RoundState):
                 "[DEBUG] DiscardState: event is None, "
                 "transition to TsumoState with prev_type=DISCARD",
             )
-            return TsumoState(prev_type=GameEventType.DISCARD)
+            next_game_event = GameEvent(
+                event_type=GameEventType.TSUMO,
+                player_seat=AbsoluteSeat.EAST,
+                action_id=-1,
+                data={},
+            )
         state = manager.get_next_state(
             previous_event_type=GameEventType.DISCARD,
             next_event=next_game_event,

--- a/app/services/game_manager/models/types.py
+++ b/app/services/game_manager/models/types.py
@@ -16,6 +16,7 @@ class GameEventType(IntEnum):
     INIT_FLOWER = 9
     HU = 10
     ROBBING_KONG = 11
+    INIT_FLOWER_OK = 12
 
     @property
     def next_event(self) -> GameEventType | None:
@@ -33,9 +34,12 @@ class GameEventType(IntEnum):
                 | GameEventType.FLOWER
                 | GameEventType.ROBBING_KONG
                 | GameEventType.INIT_FLOWER
+                | GameEventType.INIT_FLOWER_OK
             ):
                 return GameEventType.TSUMO
             case GameEventType.HU:
+                return None
+            case _:
                 return None
 
     @property


### PR DESCRIPTION
[![GAME-60](https://badgen.net/badge/JIRA/GAME-60/0052CC)](https://mcrs.atlassian.net/browse/GAME-60) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

이전까지의 게임서버-유니티 클라이언트간 연결된 통신이 게임 서버에서 클라이언트로 정보를 보내는 것 위주였다면

이번 PR에서는 클라이언트에서 메시지를 받는 것에 중점을 두었습니다

통합 테스트 과정에서 fsm구조를 변경하고, 버그를 수정하였습니다

통합 테스트 중이라 pytest는 추가/변경 하지 않았고, 디버그문이 들어간 상태입니다.

[GAME-60]: https://mcrs.atlassian.net/browse/GAME-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ