### PR TITLE
GAME-64-fixed-bug-in-melded-hand-buttons

### DIFF
--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -903,6 +903,7 @@ class RoundManager:
         return response_event
 
     async def do_action(self, current_event: GameEvent) -> RoundState:
+        self.current_player_seat = current_event.player_seat
         applied_result = self.apply_response_event(response_event=current_event)
         await self.send_response_event(
             response_event=current_event,
@@ -963,7 +964,6 @@ class RoundManager:
                     raise IndexError("kawa is empty.")
                 self.apply_call_to_visible_tiles(call_block=call_block)
                 self.kawas[self.current_player_seat].pop()
-                self.current_player_seat = response_event.player_seat
                 return call_block
 
     def apply_call_to_visible_tiles(self, call_block: CallBlock) -> None:


### PR DESCRIPTION
[![GAME-64](https://badgen.net/badge/JIRA/GAME-64/0052CC)](https://mcrs.atlassian.net/browse/GAME-64) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

통합 테스트 과정에서 전구인시 화료버튼이 떠야했는데 한번 안 떠서

턴 관리에 문제가 있는가 싶어서 라인 순서 변경했습니다

해봤는데 지금은 문제 없는거 같긴하네요

[GAME-64]: https://mcrs.atlassian.net/browse/GAME-64?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ