### PR TITLE
GAME-66-fix-furo-turn-change

### DIFF
--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -124,12 +124,14 @@ class RoundManager:
         self.player_index_to_seat = {v: k for k, v in self.seat_to_player_index.items()}
 
     async def send_init_events(self) -> None:
+        scores: list[int] = [p.score for p in self.game_manager.player_list]
         for seat in AbsoluteSeat:
             player: Player = self.get_player_from_seat(seat=seat)
             msg = WSMessage(
                 event=MessageEventType.INIT_EVENT,
                 data={
                     "player_seat": seat,
+                    "players_score": scores,
                     "hand": list(self.hands[seat].tiles.elements()),
                     "tsumo_tile": self.hands[seat].tsumo_tile,
                 },
@@ -908,6 +910,7 @@ class RoundManager:
             response_event=current_event,
             applied_result=applied_result,
         )
+        self.current_player_seat = current_event.player_seat
         match current_event.event_type:
             case GameEventType.SHOMIN_KAN:
                 tile: GameTile | None = current_event.data.get("tile", None)


### PR DESCRIPTION
[![GAME-66](https://badgen.net/badge/JIRA/GAME-66/0052CC)](https://mcrs.atlassian.net/browse/GAME-66) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

GAME-66-fix-furo-turn-change

후로 턴 처리하는걸 앞쪽 라인으로 빼니까 턴이 자신으로 바뀌고 나서 후로패에 대한 정보 전송이  이루어져서

항상 source tile이 자신이 되는 버그가 있었습니다

라인 순서 변경하여 수정했습니다

[GAME-66]: https://mcrs.atlassian.net/browse/GAME-66?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ