### PR TITLE
GAME-68-fix-concealed-hand-bug

### DIFF
--- a/app/services/game_manager/models/hand.py
+++ b/app/services/game_manager/models/hand.py
@@ -211,7 +211,7 @@ class GameHand:
             # 소명깡
             for block in self.call_blocks:
                 if block.type == CallBlockType.PUNG and (
-                    block.first_tile == tile and block.first_tile in self.tiles
+                    block.first_tile in self.tiles
                 ):
                     result.append(
                         Action(

--- a/app/services/score_calculator/block/block.py
+++ b/app/services/score_calculator/block/block.py
@@ -52,7 +52,7 @@ class Block:
         return Block(
             type=_type,
             tile=Tile(block.first_tile),
-            is_opened=(block.type == CallBlockType.AN_KONG),
+            is_opened=(block.type != CallBlockType.AN_KONG),
         )
 
     @property


### PR DESCRIPTION
[![GAME-68](https://badgen.net/badge/JIRA/GAME-68/0052CC)](https://mcrs.atlassian.net/browse/GAME-68) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

손패 후로 블럭 파싱할 때 멘젠 상태가 잘못 초기화되는 버그를 고쳤습니다.

[GAME-68]: https://mcrs.atlassian.net/browse/GAME-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ