### PR TITLE
GAME-75-fix-sending-winning-hand-bug

### DIFF
--- a/app/services/game_manager/models/manager.py
+++ b/app/services/game_manager/models/manager.py
@@ -759,10 +759,16 @@ class RoundManager:
             ]
             for hand in self.hands
         ]
+        hu_hand: list[GameTile] = list(self.hands[hu_player_seat].tiles.elements())
+        if (
+            self.winning_conditions.is_discarded
+            or self.winning_conditions.is_robbing_the_kong
+        ) and self.winning_conditions.winning_tile is not None:
+            hu_hand.append(self.winning_conditions.winning_tile)
         msg = WSMessage(
             event=MessageEventType.HU_HAND,
             data={
-                "hand": list(self.hands[hu_player_seat].tiles.elements()),
+                "hand": hu_hand,
                 "call_blocks": self.hands[hu_player_seat].call_blocks,
                 "score_result": score_result,
                 "player_seat": hu_player_seat,


### PR DESCRIPTION
[![GAME-75](https://badgen.net/badge/JIRA/GAME-75/0052CC)](https://mcrs.atlassian.net/browse/GAME-75) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

손패 전송시 론화료나 창깡화료의 경우 화료패인 그 한 장을 빼놓고 화료 손패를 전송하는 버그를 고쳤습니다.

[GAME-75]: https://mcrs.atlassian.net/browse/GAME-75?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ