### PR TITLE
GAME-88-fix-replacement-tile-bug-in-assist

### DIFF
--- a/app/services/game_manager/helpers/tenpai_assistant.py
+++ b/app/services/game_manager/helpers/tenpai_assistant.py
@@ -53,6 +53,9 @@ class TenpaiAssistant:
         if not tenpai_tiles:
             return result
         working_winning_conditions.count_tenpai_tiles = len(tenpai_tiles)
+        working_winning_conditions.is_replacement_tile = False
+        working_winning_conditions.is_robbing_the_kong = False
+        working_winning_conditions.is_last_tile_in_the_game = False
         for tenpai_tile in tenpai_tiles:
             if tenpai_hand.tiles[tenpai_tile] >= 4:
                 continue


### PR DESCRIPTION
[![GAME-88](https://badgen.net/badge/JIRA/GAME-88/0052CC)](https://mcrs.atlassian.net/browse/GAME-88) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

어시스트에서 이전에 깡을 쳤는지에 대한 flag가 반영되어 영상개화 점수가 더해지는 것을 막았습니다.

지금 깡을 쳐서 화료하지 못했다면 영상개화는 어시스트에 포함되지 않아야 합니다.

[GAME-88]: https://mcrs.atlassian.net/browse/GAME-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ