### PR TITLE
GAME-87 fix timeout double discard bug

### DIFF
--- a/app/services/game_manager/manager.py
+++ b/app/services/game_manager/manager.py
@@ -1777,11 +1777,7 @@ class GameManager:
             tile = GameTile(tile_int)
         except (ValueError, TypeError):
             return False
-        try:
-            action_id = int(event.data["action_id"])
-        except (ValueError, TypeError):
-            return False
-        if action_id != self.action_id:
+        if event.action_id != self.action_id:
             return False
         hand = self.round_manager.hands[event.player_seat]
         if hand.tiles.get(tile, 0) < 1:

--- a/app/services/game_manager/manager.py
+++ b/app/services/game_manager/manager.py
@@ -1164,7 +1164,6 @@ class RoundManager:
     async def wait_discard_after_call_action(
         self,
     ) -> GameEvent:
-        self.game_manager.increase_action_id()
         await self.game_manager.network_service.send_personal_message(
             message=WSMessage(
                 event=MessageEventType.SET_TIMER,
@@ -1320,6 +1319,7 @@ class RoundManager:
         response_event: GameEvent,
         applied_result: Any,
     ) -> None:
+        self.game_manager.increase_action_id()
         if response_event.event_type in {GameEventType.CHII, GameEventType.PON}:
             tenpai_assistant: TenpaiAssistant = TenpaiAssistant(
                 game_hand=self.hands[response_event.player_seat],
@@ -1388,6 +1388,7 @@ class RoundManager:
                     data={
                         "seat": response_event.player_seat,
                         "call_block_data": applied_result,
+                        "action_id": self.game_manager.action_id,
                         "tenpai_assist": tenpai_assist_data,
                     },
                 )
@@ -1418,6 +1419,7 @@ class RoundManager:
                     data={
                         "seat": response_event.player_seat,
                         "call_block_data": applied_result,
+                        "action_id": self.game_manager.action_id,
                         "tenpai_assist": tenpai_assist_data,
                     },
                 )
@@ -1774,6 +1776,12 @@ class GameManager:
             tile_int = int(event.data["tile"])
             tile = GameTile(tile_int)
         except (ValueError, TypeError):
+            return False
+        try:
+            action_id = int(event.data["action_id"])
+        except (ValueError, TypeError):
+            return False
+        if action_id != self.action_id:
             return False
         hand = self.round_manager.hands[event.player_seat]
         if hand.tiles.get(tile, 0) < 1:


### PR DESCRIPTION
[![GAME-87](https://badgen.net/badge/JIRA/GAME-87/0052CC)](https://mcrs.atlassian.net/browse/GAME-87) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

시간초과와 동시에 타패할 경우 타패와 시간초과로 인한 쯔모기리가 동시 적용되는 버그가 있었습니다.
action id 기반으로 timeout시 강제 타패 메세지가 전송되고 나서 action id가 증가하는것을 이용하여 플레이어의 타패 action을 받았을 때 action_id가 현재 acition_id와 다르다면 무시하는 방식으로 처리하였습니다.

[![UNITY-158](https://badgen.net/badge/JIRA/UNITY-158/0052CC)](https://mcrs.atlassian.net/browse/UNITY-158) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->
과 함께 처리하였습니다.

[GAME-87]: https://mcrs.atlassian.net/browse/GAME-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[UNITY-158]: https://mcrs.atlassian.net/browse/UNITY-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ